### PR TITLE
Add `main` property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "cheerio": "^0.17.0"
   },
+  "main": "./src/bootlint.js",
   "bin": "./src/cli.js",
   "browser": {
     "cheerio": "jquery",


### PR DESCRIPTION
Allows requiring the module by its ID and not by `./node_modules/bootlint/src/bootlint`.

See https://www.npmjs.org/doc/files/package.json.html#main and also https://github.com/zacechola/grunt-bootlint/blob/ff2d7efc506c0e8ba2b2f4df907d617d8ff36ccd/tasks/bootlint.js#L12.
