### PR TITLE
Enforce Unix line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Enforce Unix newlines
+*.css   text eol=lf
+*.html  text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.yml   text eol=lf

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,10 @@
 'use strict';
 
 module.exports = function (grunt) {
+
+  // Force use of Unix newlines
+  grunt.util.linefeed = '\n';
+
   // Load all grunt tasks
   require('load-grunt-tasks')(grunt);
   // Show elapsed time at the end.


### PR DESCRIPTION
Fixes #82, the issue on Windows with JSCS.

Now, shouldn't we have JSHint and JSCS enabled in `test` target too?
