### PR TITLE
Add @hnrch02 to `contributors` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "email": "code@rebertia.com",
     "url": "http://chrisrebert.com"
   },
+  "contributors": [{
+    "name": "Heinrich Fenkart",
+    "email": "hnrch02@gmail.com",
+    "url": "http://hnrch02.me"
+  }],
   "repository": {
     "type": "git",
     "url": "https://github.com/twbs/bootlint.git"


### PR DESCRIPTION
@hnrch02 (a fellow [Bootstrap Core Team](http://getbootstrap.com/about/#team) member) has kindly agreed to take over as Bootlint's BDFL going forward.
Since Bootlint now has all the essential features I can think of, has a good number of lint checks, has decent docs, and has its project infrastructure all set up (build scripts, CI, unit tests, code coverage, npm module), I feel comfortable handing over the reins and leaving the project in @hnrch02's capable hands. And importantly, we both agree that semicolons are mandatory :-)

FYI: @zacechola ([grunt-bootlint](https://github.com/zacechola/grunt-bootlint)'s maintainer)
