### PR TITLE
Introduce `--no-stdin` option to CLI

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -16,6 +16,7 @@ program
     .option('-d, --disable <IDs>', 'Comma-separated list of disabled lint problem IDs', function (val) {
         return val.split(',');
     })
+    .option('--no-stdin', 'Explicitly ignore the stdin stream')
     .parse(process.argv);
 var disabledIds = program.disable === undefined ? [] : program.disable;
 
@@ -44,7 +45,7 @@ function buildReporter(origin) {
 
 function handleStdin() {
     return new Deferred(function (resolve) {
-        if (typeof process.stdin.isTTY !== 'boolean' || process.stdin.isTTY) {
+        if (!program.stdin || process.stdin.isTTY) {
             return resolve();
         }
 


### PR DESCRIPTION
My previous solution broke stdin support completely since `process.stdin.isTTY` is apparently always `undefined` when stdin is not a TTY. I figured the best solution for #211 is to let the user decide whether they want Bootlint to figure out if it should read from stdin or not.

Pinging @cvrebert about the copy of the option's description.

/cc @XhmikosR 