### PR TITLE
showLintReportForCurrentDocument: add alert() config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ In a browser environment, the following public APIs are available:
   * `reporter` is a *reporter* function (see above for a definition). It will be called repeatedly with each lint problem as an argument.
   * `disabledIds` is an array of string linter IDs to disable
   * Returns nothing (i.e. `undefined`)
-* `bootlint.showLintReportForCurrentDocument(disabledIds)`: Lints the HTML of the current document and reports the linting results to the user.
-  * If there are any lint warnings, one general notification message will be `window.alert()`-ed to the user. Each warning will be output individually using `console.warn()`.
+* `bootlint.showLintReportForCurrentDocument(disabledIds, alertOpts)`: Lints the HTML of the current document and reports the linting results to the user. Each warning will be output individually using `console.warn()`.
   * `disabledIds` is an array of string linter IDs to disable
+  * `alertOpts` is an optional options object with the following properties:
+    * `hasProblems` (type: `boolean`; default: `true`) - `window.alert()` a single general notification message to the user if there are any lint problems?
+    * `problemFree` (type: `boolean`; default: `true`) - `window.alert()` a notification message to the user if the document has no lint problems?
   * Returns nothing (i.e. `undefined`)
 
 ### Node.js

--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -969,17 +969,26 @@ var LocationIndex = _location.LocationIndex;
              * If there are any lint warnings, one general notification message will be window.alert()-ed to the user.
              * Each warning will be output individually using console.warn().
              * @param {string[]} disabledIds Array of string IDs of linters to disable
+             * @param {object} [alertOpts] Options object to configure alert()ing
+             * @param {boolean} [alertOpts.hasProblems=true] Show one alert() when the first lint problem is found?
+             * @param {boolean} [alertOpts.problemFree=true] Show one alert() at the end of linting if the page has no lint problems?
              * @returns {undefined} Nothing
              */
-            exports.showLintReportForCurrentDocument = function (disabledIds) {
+            exports.showLintReportForCurrentDocument = function (disabledIds, alertOpts) {
+                alertOpts = alertOpts || {};
+                var alertOnFirstProblem = alertOpts.hasProblems || alertOpts.hasProblems === undefined;
+                var alertIfNoProblems = alertOpts.problemFree || alertOpts.problemFree === undefined;
+
                 var seenLint = false;
                 var errorCount = 0;
                 var reporter = function (lint) {
                     var background = "background: #" + (lint.id[0] === "W" ? "f0ad4e" : "d9534f") + "; color: #ffffff;";
                     if (!seenLint) {
-                        /*eslint-disable no-alert, no-undef, block-scoped-var */
-                        window.alert("bootlint found errors in this document! See the JavaScript console for details.");// jshint ignore:line
-                        /*eslint-enable no-alert, no-undef, block-scoped-var */
+                        if (alertOnFirstProblem) {
+                            /*eslint-disable no-alert, no-undef, block-scoped-var */
+                            window.alert("bootlint found errors in this document! See the JavaScript console for details.");// jshint ignore:line
+                            /*eslint-enable no-alert, no-undef, block-scoped-var */
+                        }
                         seenLint = true;
                     }
 
@@ -996,7 +1005,7 @@ var LocationIndex = _location.LocationIndex;
                 if (errorCount > 0) {
                     console.info("bootlint: For details, look up the lint problem IDs in the Bootlint wiki: https://github.com/twbs/bootlint/wiki");
                 }
-                else {
+                else if (alertIfNoProblems) {
                     /*eslint-disable no-alert, no-undef, block-scoped-var */
                     window.alert("bootlint found no errors in this document.");// jshint ignore:line
                     /*eslint-enable no-alert, no-undef, block-scoped-var */


### PR DESCRIPTION
This will also require a README update, which I'll be happy to add once the rest has been approved.
Refs https://github.com/twbs/bootlint/commit/690606bae6e5187bbd7dcd5a5c7ac85e3cc8148a#commitcomment-9256464
CC: @hnrch02 for review