### PR TITLE
Explicitly ignore containers within navbar for E004

### DIFF
--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -409,7 +409,9 @@ var LocationIndex = _location.LocationIndex;
         }
     });
     addLinter("E004", function lintNestedContainers($, reporter) {
-        var nestedContainers = $('.container, .container-fluid').children('.container, .container-fluid');
+        var nestedContainers = $('.container, .container-fluid').filter(function(i, div) {
+          return $(this).find('.navbar').length === 0;
+        }).find('.container, .container-fluid');
         if (nestedContainers.length) {
             reporter("Containers (`.container` and `.container-fluid`) are not nestable", nestedContainers);
         }

--- a/test/fixtures/containers/nested-fixed-fluid.html
+++ b/test/fixtures/containers/nested-fixed-fluid.html
@@ -21,6 +21,12 @@
             <div class="container-fluid"></div>
         </div>
 
+        <div class="container">
+          <div class="navbar">
+            <div class="container-fluid"></div>
+          </div>
+        </div>
+
         <div id="qunit"></div>
         <ol id="bootlint">
             <li data-lint="Containers (`.container` and `.container-fluid`) are not nestable"></li>


### PR DESCRIPTION
Fix #215

1. Ignore containers within `.navbar`
2. Expand search for more than just direct children.