### PR TITLE
Adds linter for checking children of `.input-group`

### DIFF
--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -938,6 +938,20 @@ var LocationIndex = _location.LocationIndex;
             reporter('`.form-control` cannot be used on non-textual `<input>`s, such as those whose `type` is: `file`, `checkbox`, `radio`, `range`, `button`', formControlsOnWrongTypes);
         }
     });
+
+    addLinter("E044", function lintInputGroupAddonChildren($, reporter) {
+        var inputGroups = $('.input-group');
+
+        inputGroups.each(function () {
+            var inputGroup = $(this);
+            var missingFormControl = !inputGroup.find('.form-control').length;
+            var missingInputGroupAddon = !inputGroup.find('.input-group-addon, .input-group-btn').length;
+
+            if (missingFormControl || missingInputGroupAddon) {
+                reporter('`.input-group` must have a `.form-control` and either `.input-group-addon` or `.input-group-btn`.', inputGroup);
+            }
+        });
+    });
     addLinter("W009", function lintEmptySpacerCols($, reporter) {
         var selector = COL_CLASSES.map(function (colClass) {
             return colClass + ':not(:last-child)';

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -270,6 +270,16 @@ exports.bootlint = {
             'should complain when an input group has a grid column class on it.');
         test.done();
     },
+    'input groups missing controls and addons': function (test) {
+        test.expect(2);
+        test.deepEqual(lintHtml(utf8Fixture('input-group/missing-input-group-addon.html')),
+            ["`.input-group` must have a `.form-control` and either `.input-group-addon` or `.input-group-btn`."],
+            'should complain when missing missing a `.form-control`');
+        test.deepEqual(lintHtml(utf8Fixture('input-group/missing-form-control.html')),
+            ["`.input-group` must have a `.form-control` and either `.input-group-addon` or `.input-group-btn`."],
+            'should complain when missing missing a `.input-group-addon`');
+        test.done();
+    },
     'non-column children of rows': function (test) {
         test.expect(2);
         test.deepEqual(lintHtml(utf8Fixture('grid/non-col-row-children.html')),

--- a/test/fixtures/input-group/missing-form-control.html
+++ b/test/fixtures/input-group/missing-form-control.html
@@ -17,14 +17,14 @@
         <script src="../generic-qunit.js"></script>
     </head>
     <body>
-        <div class="input-group">
-            <span class="input-group-addon">@</span>
-            <textarea class="form-control">Abomination</textarea>
-        </div>
+
+      <div class="input-group">
+        <input class="form-control" type="text">
+      </div>
 
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="`.input-group` contains a `&lt;textarea&gt;`; only text-based `&lt;input&gt;`s are permitted in an `.input-group`"></li>
+          <li data-lint="`.input-group` must have a `.form-control` and either `.input-group-addon` or `.input-group-btn`."></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/input-group/missing-input-group-addon.html
+++ b/test/fixtures/input-group/missing-input-group-addon.html
@@ -17,14 +17,14 @@
         <script src="../generic-qunit.js"></script>
     </head>
     <body>
-        <div class="input-group">
-            <span class="input-group-addon">@</span>
-            <textarea class="form-control">Abomination</textarea>
-        </div>
+
+      <div class="input-group">
+        <span class="input-group-addon">@</span>
+      </div>
 
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="`.input-group` contains a `&lt;textarea&gt;`; only text-based `&lt;input&gt;`s are permitted in an `.input-group`"></li>
+          <li data-lint="`.input-group` must have a `.form-control` and either `.input-group-addon` or `.input-group-btn`."></li>
         </ol>
     </body>
 </html>


### PR DESCRIPTION
Check that `.input-group` has at least one `.form-control` and at least
one of `.input-group-addon` or `.input-group-btn`.

Adds [E044](https://github.com/twbs/bootlint/wiki/E044).

Closes #274.