### PR TITLE
Add check for btn usage within .navbar-nav

### DIFF
--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -938,6 +938,16 @@ var LocationIndex = _location.LocationIndex;
             reporter('`.form-control` cannot be used on non-textual `<input>`s, such as those whose `type` is: `file`, `checkbox`, `radio`, `range`, `button`', formControlsOnWrongTypes);
         }
     });
+    addLinter("E043", function lintNavbarButtons($, reporter) {
+        var navAnchorBtns = $('.navbar-nav a.btn');
+        var anchorNavbarBtns = $('.navbar-nav a.navbar-btn');
+        if (navAnchorBtns.length) {
+            reporter('`.btn` cannot be used on `<a>`s, within `.navbar-nav`', navAnchorBtns);
+        }
+        if (anchorNavbarBtns.length) {
+            reporter('`.navbar-btn` cannot be used on `<a>`s, within `.navbar-nav`', anchorNavbarBtns);
+        }
+    });
     addLinter("W009", function lintEmptySpacerCols($, reporter) {
         var selector = COL_CLASSES.map(function (colClass) {
             return colClass + ':not(:last-child)';

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -860,5 +860,18 @@ exports.bootlint = {
             'should not complain about usage of .form-control on valid elements and input types.'
         );
         test.done();
+    },
+
+    'navbar buttons': function (test) {
+        test.expect(2);
+        test.deepEqual(lintHtml(utf8Fixture('navbar/navbar-btn-bad.html')),
+            ['`.btn` cannot be used on `<a>`s, within `.navbar-nav`'],
+            'should complain about a .btn within the .navbar-nav class.'
+        );
+        test.deepEqual(lintHtml(utf8Fixture('navbar/navbar-navbar_btn-bad.html')),
+            ['`.navbar-btn` cannot be used on `<a>`s, within `.navbar-nav`'],
+            'should complain about a .navbar-btn within the .navbar-nav class.'
+        );
+        test.done();
     }
 };

--- a/test/fixtures/navbar/navbar-btn-bad.html
+++ b/test/fixtures/navbar/navbar-btn-bad.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Test</title>
+        <!--[if lt IE 9]>
+            <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+            <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+        <script src="../../lib/jquery.min.js"></script>
+
+        <link rel="stylesheet" href="../../lib/qunit.css">
+        <script src="../../lib/qunit.js"></script>
+        <script src="../../../dist/browser/bootlint.js"></script>
+        <script src="../generic-qunit.js"></script>
+    </head>
+    <body>
+        <nav class="navbar navbar-default">
+            <div class="container-fluid">
+                <!-- Brand and toggle get grouped for better mobile display -->
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    <a class="navbar-brand" href="#">Brand</a>
+                </div>
+
+                <!-- Collect the nav links, forms, and other content for toggling -->
+                <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+                    <ul class="nav navbar-nav">
+                        <li class="active">
+                            <a href="#">Link <span class="sr-only">(current)</span></a>
+                        </li>
+                        <li><a href="#" class="btn">Link</a></li>
+                    </ul>
+                </div><!-- /.navbar-collapse -->
+            </div><!-- /.container-fluid -->
+        </nav>
+
+        <div id="qunit"></div>
+        <ol id="bootlint">
+            <li data-lint="`.btn` cannot be used on `<a>`s, within `.navbar-nav`"></li>
+        </ol>
+    </body>
+</html>

--- a/test/fixtures/navbar/navbar-navbar_btn-bad.html
+++ b/test/fixtures/navbar/navbar-navbar_btn-bad.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Test</title>
+        <!--[if lt IE 9]>
+            <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+            <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+        <script src="../../lib/jquery.min.js"></script>
+
+        <link rel="stylesheet" href="../../lib/qunit.css">
+        <script src="../../lib/qunit.js"></script>
+        <script src="../../../dist/browser/bootlint.js"></script>
+        <script src="../generic-qunit.js"></script>
+    </head>
+    <body>
+        <nav class="navbar navbar-default">
+            <div class="container-fluid">
+                <!-- Brand and toggle get grouped for better mobile display -->
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    <a class="navbar-brand" href="#">Brand</a>
+                </div>
+
+                <!-- Collect the nav links, forms, and other content for toggling -->
+                <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+                    <ul class="nav navbar-nav">
+                        <li class="active">
+                            <a href="#">Link <span class="sr-only">(current)</span></a>
+                        </li>
+                        <li><a href="#" class="navbar-btn">Link</a></li>
+                    </ul>
+                </div><!-- /.navbar-collapse -->
+            </div><!-- /.container-fluid -->
+        </nav>
+
+        <div id="qunit"></div>
+        <ol id="bootlint">
+            <li data-lint="`.navbar-btn` cannot be used on `<a>`s, within `.navbar-nav`"></li>
+        </ol>
+    </body>
+</html>


### PR DESCRIPTION
[Fix #273] Add check for btn usage within `.navbar-nav`

NOTE: I wasn't able to add a file to bootlint_test.js. For whatever reason I always am getting "expected x assertations, 0 ran" where x is whatever number I try to add.

The tests I attempted to add:

```javascript
'navbar buttons': function (test) {
        test.expect(2);
        test.deepEqual(lintHtml(utf8Fixture('navbar/navbar-btn-bad.html')),
            ['`.btn` cannot be used on `<a>`s, within `.navbar-nav`'],
            'should complain about a .btn within the .navbar-nav class.'
        );
        test.deepEqual(lintHtml(utf8Fixture('navbar/navbar-navbar_btn-bad.html')),
            ['`.navbar-btn` cannot be used on `<a>`s, within `.navbar-nav`'],
            'should complain about a .navbar-btn within the .navbar-nav class.'
        );
        test.done();
    }
```

The tests in the fixtures themselves though are working as expected.

EDIT: This will require updating the wiki as this was a reserved error number