### PR TITLE
Require Grunt Explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "license": "MIT",
   "devDependencies": {
     "coveralls": "^2.11.2",
+    "grunt": "^0.4.5",
     "grunt-banner": "^0.3.1",
     "grunt-browserify": "^3.2.0",
     "grunt-contrib-clean": "^0.6.0",

--- a/test-infra/npm-shrinkwrap.json
+++ b/test-infra/npm-shrinkwrap.json
@@ -1,7 +1,7 @@
 {
   "name": "bootlint",
   "version": "0.12.0",
-  "npm-shrinkwrap-version": "200.1.0",
+  "npm-shrinkwrap-version": "200.4.0",
   "node-version": "v0.12.2",
   "dependencies": {
     "binary-search": {
@@ -9,12 +9,12 @@
       "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.2.0.tgz"
     },
     "bluebird": {
-      "version": "2.9.24",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
+      "version": "2.9.27",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.27.tgz"
     },
     "body-parser": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.2.tgz",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz",
       "dependencies": {
         "bytes": {
           "version": "1.0.0",
@@ -24,27 +24,17 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
         },
-        "debug": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
-            }
-          }
-        },
         "depd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "iconv-lite": {
-          "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
         },
         "on-finished": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
@@ -53,28 +43,34 @@
           }
         },
         "qs": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
         },
         "raw-body": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.3.tgz"
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.1.tgz",
+          "dependencies": {
+            "bytes": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.0.1.tgz"
+            }
+          }
         },
         "type-is": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz",
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.2.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "version": "2.0.11",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.11.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.8.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "version": "1.9.1",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.9.1.tgz"
                 }
               }
             }
@@ -184,23 +180,7 @@
             },
             "domutils": {
               "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-              "dependencies": {
-                "dom-serializer": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                    },
-                    "entities": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-                    }
-                  }
-                }
-              }
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
             },
             "entities": {
               "version": "1.0.0",
@@ -231,14 +211,14 @@
           }
         },
         "lodash": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.8.0.tgz"
         }
       }
     },
     "commander": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "dependencies": {
         "graceful-readlink": {
           "version": "1.0.1",
@@ -383,14 +363,8 @@
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "tough-cookie": {
-              "version": "0.12.1",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-              "dependencies": {
-                "punycode": {
-                  "version": "1.3.2",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                }
-              }
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
@@ -401,36 +375,36 @@
       }
     },
     "debug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "dependencies": {
         "ms": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         }
       }
     },
     "express": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.12.3.tgz",
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.12.4.tgz",
       "dependencies": {
         "accepts": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.5.tgz",
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.7.tgz",
           "dependencies": {
             "mime-types": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "version": "2.0.11",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.11.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.8.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "version": "1.9.1",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.9.1.tgz"
                 }
               }
             },
             "negotiator": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
+              "version": "0.5.3",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
             }
           }
         },
@@ -450,27 +424,17 @@
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
-        "debug": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
-            }
-          }
-        },
         "depd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "escape-html": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
         },
         "etag": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.6.0.tgz",
           "dependencies": {
             "crc": {
               "version": "3.2.1",
@@ -479,8 +443,8 @@
           }
         },
         "finalhandler": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.4.tgz"
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.6.tgz"
         },
         "fresh": {
           "version": "0.2.4",
@@ -495,8 +459,8 @@
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
         },
         "on-finished": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
@@ -513,30 +477,30 @@
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
         },
         "proxy-addr": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.7.tgz",
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.8.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
-              "version": "0.1.9",
-              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz"
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.1.tgz"
             }
           }
         },
         "qs": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
         },
         "range-parser": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
         },
         "send": {
-          "version": "0.12.2",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.12.2.tgz",
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.12.3.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.3",
@@ -547,30 +511,30 @@
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "serve-static": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.2.tgz"
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.3.tgz"
         },
         "type-is": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz",
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.2.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+              "version": "2.0.11",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.11.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.8.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                  "version": "1.9.1",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.9.1.tgz"
                 }
               }
             }
@@ -587,8 +551,8 @@
       }
     },
     "glob": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.3.tgz",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.10.tgz",
       "dependencies": {
         "inflight": {
           "version": "1.0.4",
@@ -605,8 +569,8 @@
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "minimatch": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
@@ -625,14 +589,18 @@
           }
         },
         "once": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         }
       }
     },
@@ -681,8 +649,8 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "version": "2.6.3",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
@@ -693,8 +661,8 @@
               }
             },
             "lodash": {
-              "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
@@ -721,8 +689,8 @@
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
-              "version": "2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
@@ -775,8 +743,8 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+              "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.3.tgz"
             },
             "sigmund": {
               "version": "1.0.0",
@@ -813,24 +781,24 @@
       "resolved": "https://registry.npmjs.org/grunt-banner/-/grunt-banner-0.3.1.tgz"
     },
     "grunt-browserify": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/grunt-browserify/-/grunt-browserify-3.6.0.tgz",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/grunt-browserify/-/grunt-browserify-3.8.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "browserify": {
-          "version": "9.0.7",
-          "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.7.tgz",
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.2.0.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "0.10.0",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.3.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
                 },
                 "through": {
                   "version": "2.3.7",
@@ -843,50 +811,28 @@
               "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
             },
             "browser-pack": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.1.tgz",
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.0.tgz",
               "dependencies": {
-                "JSONStream": {
-                  "version": "0.8.4",
-                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-                  "dependencies": {
-                    "jsonparse": {
-                      "version": "0.0.5",
-                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
-                    },
-                    "through": {
-                      "version": "2.3.7",
-                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
-                    }
-                  }
-                },
                 "combine-source-map": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
                   "dependencies": {
                     "convert-source-map": {
-                      "version": "0.3.5",
-                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
                     },
                     "inline-source-map": {
-                      "version": "0.3.1",
-                      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
-                      "dependencies": {
-                        "source-map": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
-                          "dependencies": {
-                            "amdefine": {
-                              "version": "0.1.0",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                            }
-                          }
-                        }
-                      }
+                      "version": "0.5.0",
+                      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+                    },
+                    "lodash.memoize": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.3.tgz"
                     },
                     "source-map": {
-                      "version": "0.1.43",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
@@ -896,47 +842,15 @@
                     }
                   }
                 },
-                "through2": {
-                  "version": "0.5.1",
-                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        }
-                      }
-                    },
-                    "xtend": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-                    }
-                  }
-                },
                 "umd": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.0.tgz"
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
                 }
               }
             },
             "browser-resolve": {
-              "version": "1.8.2",
-              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.8.2.tgz"
+              "version": "1.9.0",
+              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz"
             },
             "browserify-zlib": {
               "version": "0.1.4",
@@ -949,16 +863,16 @@
               }
             },
             "buffer": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz",
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.2.2.tgz",
               "dependencies": {
                 "base64-js": {
                   "version": "0.0.8",
                   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
                 },
                 "ieee754": {
-                  "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+                  "version": "1.1.5",
+                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz"
                 },
                 "is-array": {
                   "version": "1.0.1",
@@ -978,28 +892,6 @@
               "version": "1.4.8",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
               "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                  }
-                },
                 "typedarray": {
                   "version": "0.0.6",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
@@ -1021,24 +913,24 @@
               "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
             },
             "crypto-browserify": {
-              "version": "3.9.13",
-              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
+              "version": "3.9.14",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
               "dependencies": {
                 "browserify-aes": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
                 },
                 "browserify-sign": {
-                  "version": "2.8.0",
-                  "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.1.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "1.3.0",
                       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
                     },
                     "browserify-rsa": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
                     },
                     "elliptic": {
                       "version": "1.0.1",
@@ -1051,38 +943,26 @@
                         "hash.js": {
                           "version": "1.0.2",
                           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "parse-asn1": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                       "dependencies": {
                         "asn1.js": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.5.tgz",
                           "dependencies": {
-                            "inherits": {
-                              "version": "2.0.1",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
                             "minimalistic-assert": {
                               "version": "1.0.0",
                               "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
                         },
-                        "asn1.js-rfc3280": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
-                        },
-                        "pemstrip": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
+                        "pbkdf2-compat": {
+                          "version": "3.0.2",
+                          "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
                         }
                       }
                     }
@@ -1117,12 +997,12 @@
                   "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
                   "dependencies": {
                     "ripemd160": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
                     },
                     "sha.js": {
-                      "version": "2.4.0",
-                      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.0.tgz"
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.1.tgz"
                     }
                   }
                 },
@@ -1142,10 +1022,6 @@
                       "version": "1.1.5",
                       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
                       "dependencies": {
-                        "bn.js": {
-                          "version": "1.3.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
-                        },
                         "brorand": {
                           "version": "1.0.5",
                           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
@@ -1154,9 +1030,9 @@
                     }
                   }
                 },
-                "pbkdf2-compat": {
-                  "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
+                "pbkdf2": {
+                  "version": "3.0.4",
+                  "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
                 },
                 "public-encrypt": {
                   "version": "2.0.0",
@@ -1168,26 +1044,16 @@
                     },
                     "browserify-rsa": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz",
-                      "dependencies": {
-                        "bn.js": {
-                          "version": "1.3.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
                     },
                     "parse-asn1": {
                       "version": "3.0.0",
                       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
                       "dependencies": {
                         "asn1.js": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.5.tgz",
                           "dependencies": {
-                            "bn.js": {
-                              "version": "1.3.0",
-                              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
-                            },
                             "minimalistic-assert": {
                               "version": "1.0.0",
                               "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
@@ -1196,33 +1062,7 @@
                         },
                         "pbkdf2-compat": {
                           "version": "3.0.2",
-                          "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz",
-                          "dependencies": {
-                            "create-hmac": {
-                              "version": "1.1.3",
-                              "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
-                              "dependencies": {
-                                "create-hash": {
-                                  "version": "1.1.0",
-                                  "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz",
-                                  "dependencies": {
-                                    "ripemd160": {
-                                      "version": "1.0.0",
-                                      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
-                                    },
-                                    "sha.js": {
-                                      "version": "2.3.6",
-                                      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
-                                    }
-                                  }
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
                         }
                       }
                     }
@@ -1239,31 +1079,13 @@
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
             },
             "defined": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
             },
             "deps-sort": {
-              "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+              "version": "1.3.8",
+              "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.8.tgz",
               "dependencies": {
-                "JSONStream": {
-                  "version": "0.8.4",
-                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-                  "dependencies": {
-                    "jsonparse": {
-                      "version": "0.0.5",
-                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
-                    },
-                    "through": {
-                      "version": "2.3.7",
-                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
-                    }
-                  }
-                },
-                "minimist": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
-                },
                 "through2": {
                   "version": "0.5.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
@@ -1275,18 +1097,6 @@
                         "core-util-is": {
                           "version": "1.0.1",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     },
@@ -1304,31 +1114,7 @@
             },
             "duplexer2": {
               "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                  }
-                }
-              }
+              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
             },
             "events": {
               "version": "1.0.2",
@@ -1349,8 +1135,8 @@
                   }
                 },
                 "minimatch": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "version": "2.0.7",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
@@ -1369,8 +1155,8 @@
                   }
                 },
                 "once": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
@@ -1383,6 +1169,10 @@
             "has": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/has/-/has-1.0.0.tgz"
+            },
+            "htmlescape": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.0.tgz"
             },
             "http-browserify": {
               "version": "1.7.0",
@@ -1403,19 +1193,9 @@
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "insert-module-globals": {
-              "version": "6.2.1",
-              "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
+              "version": "6.4.2",
+              "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.4.2.tgz",
               "dependencies": {
-                "JSONStream": {
-                  "version": "0.7.4",
-                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
-                  "dependencies": {
-                    "jsonparse": {
-                      "version": "0.0.5",
-                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
-                    }
-                  }
-                },
                 "combine-source-map": {
                   "version": "0.3.0",
                   "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
@@ -1453,24 +1233,20 @@
                   }
                 },
                 "lexical-scope": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
                   "dependencies": {
                     "astw": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/astw/-/astw-1.1.0.tgz",
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                       "dependencies": {
-                        "esprima-fb": {
-                          "version": "3001.1.0-dev-harmony-fb",
-                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                        "acorn": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                         }
                       }
                     }
                   }
-                },
-                "process": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
                 },
                 "through": {
                   "version": "2.3.7",
@@ -1494,95 +1270,29 @@
                       "version": "0.0.1",
                       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                     },
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        }
-                      }
-                    },
                     "readable-wrap": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "through2": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-                      "dependencies": {
-                        "xtend": {
-                          "version": "4.0.0",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                     }
                   }
                 }
               }
             },
             "module-deps": {
-              "version": "3.7.6",
-              "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.6.tgz",
+              "version": "3.7.12",
+              "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.7.12.tgz",
               "dependencies": {
-                "JSONStream": {
-                  "version": "0.7.4",
-                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
-                  "dependencies": {
-                    "jsonparse": {
-                      "version": "0.0.5",
-                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
-                    },
-                    "through": {
-                      "version": "2.3.7",
-                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
-                    }
-                  }
-                },
                 "detective": {
-                  "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.0.tgz",
+                  "version": "4.0.2",
+                  "resolved": "https://registry.npmjs.org/detective/-/detective-4.0.2.tgz",
                   "dependencies": {
                     "acorn": {
-                      "version": "0.9.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+                    },
+                    "defined": {
+                      "version": "0.0.0",
+                      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
                     },
                     "escodegen": {
                       "version": "1.6.1",
@@ -1617,16 +1327,16 @@
                               "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                             },
                             "prelude-ls": {
-                              "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                              "version": "1.1.2",
+                              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                             },
                             "type-check": {
                               "version": "0.3.1",
                               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                             },
                             "wordwrap": {
-                              "version": "0.0.2",
-                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                              "version": "0.0.3",
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                             }
                           }
                         },
@@ -1641,32 +1351,6 @@
                           }
                         }
                       }
-                    }
-                  }
-                },
-                "minimist": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
                 },
@@ -1685,18 +1369,6 @@
                             "core-util-is": {
                               "version": "1.0.1",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             }
                           }
                         },
@@ -1705,16 +1377,6 @@
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                         }
                       }
-                    }
-                  }
-                },
-                "subarg": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.10",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
                 },
@@ -1729,18 +1391,6 @@
                         "core-util-is": {
                           "version": "1.0.1",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         }
                       }
                     },
@@ -1755,10 +1405,6 @@
                       }
                     }
                   }
-                },
-                "xtend": {
-                  "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
@@ -1781,12 +1427,12 @@
               "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
             },
             "process": {
-              "version": "0.10.1",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.0.tgz"
             },
             "punycode": {
-              "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             },
             "querystring-es3": {
               "version": "0.2.1",
@@ -1842,31 +1488,7 @@
             },
             "stream-browserify": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                  }
-                }
-              }
+              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
@@ -1883,28 +1505,22 @@
               }
             },
             "syntax-error": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.3.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "0.9.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
                 }
               }
             },
             "through2": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-              "dependencies": {
-                "xtend": {
-                  "version": "4.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
             },
             "timers-browserify": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz"
             },
             "tty-browserify": {
               "version": "0.0.0",
@@ -1914,10 +1530,6 @@
               "version": "0.10.3",
               "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
               "dependencies": {
-                "punycode": {
-                  "version": "1.3.2",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                },
                 "querystring": {
                   "version": "0.2.0",
                   "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
@@ -1939,90 +1551,196 @@
               }
             },
             "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-            }
-          }
-        },
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "lodash": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.8.0.tgz"
         },
         "resolve": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
         },
         "watchify": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/watchify/-/watchify-2.6.2.tgz",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.2.1.tgz",
           "dependencies": {
             "chokidar": {
-              "version": "0.12.6",
-              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-0.12.6.tgz",
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
               "dependencies": {
+                "anymatch": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "dependencies": {
+                    "micromatch": {
+                      "version": "2.1.6",
+                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
+                      "dependencies": {
+                        "arr-diff": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+                          "dependencies": {
+                            "array-slice": {
+                              "version": "0.2.3",
+                              "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                            }
+                          }
+                        },
+                        "braces": {
+                          "version": "1.8.0",
+                          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                          "dependencies": {
+                            "expand-range": {
+                              "version": "1.8.1",
+                              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                              "dependencies": {
+                                "fill-range": {
+                                  "version": "2.2.2",
+                                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                                  "dependencies": {
+                                    "is-number": {
+                                      "version": "1.1.2",
+                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                                    },
+                                    "isobject": {
+                                      "version": "1.0.0",
+                                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
+                                    },
+                                    "randomatic": {
+                                      "version": "1.1.0",
+                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "preserve": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                            },
+                            "repeat-element": {
+                              "version": "1.1.2",
+                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "expand-brackets": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
+                        },
+                        "filename-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                        },
+                        "kind-of": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                        },
+                        "object.omit": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
+                          "dependencies": {
+                            "for-own": {
+                              "version": "0.1.3",
+                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "0.1.4",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                }
+                              }
+                            },
+                            "isobject": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                            }
+                          }
+                        },
+                        "parse-glob": {
+                          "version": "3.0.2",
+                          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                          "dependencies": {
+                            "glob-base": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                            },
+                            "is-dotfile": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
+                            },
+                            "is-extglob": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "regex-cache": {
+                          "version": "0.4.2",
+                          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                          "dependencies": {
+                            "is-equal-shallow": {
+                              "version": "0.1.2",
+                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
+                              "dependencies": {
+                                "is-primitive": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "is-primitive": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "arrify": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+                },
                 "async-each": {
                   "version": "0.1.6",
                   "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
                 },
                 "fsevents": {
-                  "version": "0.3.5",
-                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.5.tgz",
+                  "version": "0.3.6",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "1.5.3",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
+                      "version": "1.8.4",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                     }
                   }
+                },
+                "glob-parent": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+                },
+                "is-binary-path": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+                  "dependencies": {
+                    "binary-extensions": {
+                      "version": "1.3.1",
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
                 },
                 "readdirp": {
                   "version": "1.3.0",
@@ -2037,8 +1755,8 @@
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.5.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                          "version": "2.6.3",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.3.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
@@ -2072,9 +1790,41 @@
                 }
               }
             },
+            "defined": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+            },
+            "outpipe": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+              "dependencies": {
+                "shell-quote": {
+                  "version": "1.4.3",
+                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+                  "dependencies": {
+                    "array-filter": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+                    },
+                    "array-map": {
+                      "version": "0.0.0",
+                      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+                    },
+                    "array-reduce": {
+                      "version": "0.0.0",
+                      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+                    },
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
             "through2": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "version": "0.6.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
@@ -2097,10 +1847,6 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
-                },
-                "xtend": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                 }
               }
             },
@@ -2123,16 +1869,16 @@
       }
     },
     "grunt-contrib-jshint": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.11.1.tgz",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.11.2.tgz",
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jshint": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.6.3.tgz",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.7.0.tgz",
           "dependencies": {
             "cli": {
               "version": "0.6.6",
@@ -2151,8 +1897,8 @@
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.5.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                          "version": "2.6.3",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.3.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
@@ -2238,17 +1984,27 @@
                 }
               }
             },
+            "lodash": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+            },
             "minimatch": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "version": "2.0.7",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
               "dependencies": {
-                "lru-cache": {
-                  "version": "2.5.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
                 }
               }
             },
@@ -2259,10 +2015,6 @@
             "strip-json-comments": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-            },
-            "underscore": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
             }
           }
         }
@@ -2275,148 +2027,6 @@
         "hooker": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
-        },
-        "nodeunit": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.9.1.tgz",
-          "dependencies": {
-            "tap": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/tap/-/tap-0.7.1.tgz",
-              "dependencies": {
-                "buffer-equal": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
-                },
-                "deep-equal": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
-                },
-                "difflet": {
-                  "version": "0.2.6",
-                  "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
-                  "dependencies": {
-                    "charm": {
-                      "version": "0.1.2",
-                      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
-                    },
-                    "deep-is": {
-                      "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                    },
-                    "traverse": {
-                      "version": "0.6.6",
-                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
-                    }
-                  }
-                },
-                "glob": {
-                  "version": "4.5.3",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "2.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.1",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "mkdirp": {
-                  "version": "0.5.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                    }
-                  }
-                },
-                "runforcover": {
-                  "version": "0.0.2",
-                  "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
-                  "dependencies": {
-                    "bunker": {
-                      "version": "0.1.2",
-                      "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
-                      "dependencies": {
-                        "burrito": {
-                          "version": "0.2.12",
-                          "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
-                          "dependencies": {
-                            "traverse": {
-                              "version": "0.5.2",
-                              "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
-                            },
-                            "uglify-js": {
-                              "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "slide": {
-                  "version": "1.1.6",
-                  "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-                },
-                "yamlish": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -2453,8 +2063,8 @@
                       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz"
                     },
                     "rimraf": {
-                      "version": "2.3.2",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+                      "version": "2.3.3",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.3.tgz",
                       "dependencies": {
                         "glob": {
                           "version": "4.5.3",
@@ -2475,8 +2085,8 @@
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "minimatch": {
-                              "version": "2.0.4",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                              "version": "2.0.7",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.0",
@@ -2495,8 +2105,8 @@
                               }
                             },
                             "once": {
-                              "version": "1.3.1",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                              "version": "1.3.2",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
@@ -2537,8 +2147,8 @@
                       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
                     },
                     "mkdirp": {
-                      "version": "0.5.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
@@ -2557,8 +2167,8 @@
                       }
                     },
                     "once": {
-                      "version": "1.3.1",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "version": "1.3.2",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
@@ -2571,8 +2181,8 @@
                       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
                     },
                     "semver": {
-                      "version": "4.3.3",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+                      "version": "4.3.4",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
                     },
                     "uid-number": {
                       "version": "0.0.5",
@@ -2717,14 +2327,8 @@
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                     },
                     "tough-cookie": {
-                      "version": "0.12.1",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
-                      "dependencies": {
-                        "punycode": {
-                          "version": "1.3.2",
-                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                        }
-                      }
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.0",
@@ -2805,8 +2409,8 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "version": "2.6.3",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.3.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
@@ -2819,8 +2423,8 @@
           }
         },
         "lodash": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "tiny-lr-fork": {
           "version": "0.0.5",
@@ -2862,82 +2466,10 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-10.0.0.tgz",
       "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
         "eslint": {
           "version": "0.18.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.18.0.tgz",
           "dependencies": {
-            "chalk": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-                },
-                "has-ansi": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "0.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "0.2.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-                }
-              }
-            },
             "concat-stream": {
               "version": "1.4.8",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
@@ -3001,8 +2533,8 @@
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.6",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                      "version": "0.10.7",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                       "dependencies": {
                         "es6-symbol": {
                           "version": "2.0.1",
@@ -3022,33 +2554,7 @@
                     },
                     "es6-set": {
                       "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
-                      "dependencies": {
-                        "es6-symbol": {
-                          "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
-                          "dependencies": {
-                            "d": {
-                              "version": "0.1.1",
-                              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                            },
-                            "es5-ext": {
-                              "version": "0.10.6",
-                              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
-                              "dependencies": {
-                                "es6-iterator": {
-                                  "version": "0.1.3",
-                                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
-                                },
-                                "es6-symbol": {
-                                  "version": "2.0.1",
-                                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
                     },
                     "es6-symbol": {
                       "version": "0.1.1",
@@ -3061,36 +2567,24 @@
                   }
                 },
                 "es6-weak-map": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
+                  "version": "0.1.4",
+                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
-                      "version": "0.10.6",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
-                      "dependencies": {
-                        "es6-symbol": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                        }
-                      }
+                      "version": "0.10.7",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
                     },
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                      "dependencies": {
-                        "es6-symbol": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                     },
                     "es6-symbol": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
@@ -3121,16 +2615,16 @@
               "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
             },
             "js-yaml": {
-              "version": "3.2.7",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+              "version": "3.3.1",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
-                      "version": "3.6.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                      "version": "3.8.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.8.0.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.2",
@@ -3139,14 +2633,14 @@
                   }
                 },
                 "esprima": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "version": "2.0.7",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -3165,8 +2659,8 @@
               }
             },
             "mkdirp": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
@@ -3195,16 +2689,16 @@
                   "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                 },
                 "prelude-ls": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                 },
                 "type-check": {
                   "version": "0.3.1",
                   "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                 },
                 "wordwrap": {
-                  "version": "0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 }
               }
             },
@@ -3233,16 +2727,16 @@
       "resolved": "https://registry.npmjs.org/grunt-exec/-/grunt-exec-0.4.6.tgz"
     },
     "grunt-jscs": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.6.0.tgz",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.8.0.tgz",
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jscs": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.12.0.tgz",
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
           "dependencies": {
             "cli-table": {
               "version": "0.3.1",
@@ -3263,8 +2757,8 @@
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "esprima-harmony-jscs": {
-              "version": "1.1.0-templates",
-              "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-templates.tgz"
+              "version": "1.1.0-bin",
+              "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-bin.tgz"
             },
             "estraverse": {
               "version": "1.9.3",
@@ -3274,87 +2768,61 @@
               "version": "0.1.2",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
-            "glob": {
-              "version": "5.0.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.3.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
             "lodash.assign": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
-                  "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.0.2.tgz",
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.1.1.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.2",
+                      "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.2.tgz"
                     },
                     "lodash.keys": {
-                      "version": "3.0.5",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.5.tgz",
+                      "version": "3.0.7",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.7.tgz",
                       "dependencies": {
                         "lodash.isarguments": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.1.tgz"
+                          "version": "3.0.2",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.2.tgz"
                         },
                         "lodash.isarray": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.1.tgz"
-                        },
-                        "lodash.isnative": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.1.tgz"
+                          "version": "3.0.2",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.2.tgz"
                         }
                       }
                     }
                   }
                 },
                 "lodash._createassigner": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.0.1.tgz",
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.0.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.0.tgz"
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                     },
                     "lodash._isiterateecall": {
-                      "version": "3.0.5",
-                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.5.tgz"
+                      "version": "3.0.7",
+                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.7.tgz"
+                    },
+                    "lodash.restparam": {
+                      "version": "3.6.1",
+                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                     }
                   }
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "version": "2.0.7",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -3371,6 +2839,10 @@
                   }
                 }
               }
+            },
+            "pathval": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
             },
             "prompt": {
               "version": "0.2.14",
@@ -3411,8 +2883,8 @@
                       "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                     },
                     "mkdirp": {
-                      "version": "0.5.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
@@ -3425,8 +2897,8 @@
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                     },
                     "rimraf": {
-                      "version": "2.3.2",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+                      "version": "2.3.3",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.3.tgz",
                       "dependencies": {
                         "glob": {
                           "version": "4.5.3",
@@ -3446,29 +2918,9 @@
                               "version": "2.0.1",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
-                            "minimatch": {
-                              "version": "2.0.4",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.0",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.2.0",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
                             "once": {
-                              "version": "1.3.1",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                              "version": "1.3.2",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
@@ -3518,14 +2970,6 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
-            "supports-color": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz"
-            },
-            "vow": {
-              "version": "0.4.9",
-              "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.9.tgz"
-            },
             "vow-fs": {
               "version": "0.3.4",
               "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
@@ -3548,29 +2992,9 @@
                       "version": "2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
-                    "minimatch": {
-                      "version": "2.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
                     "once": {
-                      "version": "1.3.1",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "version": "1.3.2",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
@@ -3584,19 +3008,9 @@
                   "version": "1.4.3",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
-                "vow": {
-                  "version": "0.4.9",
-                  "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.9.tgz"
-                },
                 "vow-queue": {
                   "version": "0.4.1",
-                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz",
-                  "dependencies": {
-                    "vow": {
-                      "version": "0.4.9",
-                      "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.9.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz"
                 }
               }
             },
@@ -3613,8 +3027,8 @@
           }
         },
         "lodash": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "vow": {
           "version": "0.4.9",
@@ -3623,16 +3037,16 @@
       }
     },
     "jquery": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz"
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz"
     },
     "jscoverage": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/jscoverage/-/jscoverage-0.5.9.tgz",
       "dependencies": {
         "coffee-script": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.1.tgz"
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.2.tgz"
         },
         "debug": {
           "version": "1.0.3",
@@ -3653,8 +3067,8 @@
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.1.tgz",
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             }
           }
         },
@@ -3671,8 +3085,8 @@
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "dependencies": {
                 "wordwrap": {
-                  "version": "0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 }
               }
             },
@@ -3698,437 +3112,29 @@
         }
       }
     },
-    "jscs": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.12.0.tgz",
-      "dependencies": {
-        "cli-table": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-          "dependencies": {
-            "colors": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-            }
-          }
-        },
-        "commander": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
-        },
-        "esprima": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
-        },
-        "esprima-harmony-jscs": {
-          "version": "1.1.0-templates",
-          "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-templates.tgz"
-        },
-        "estraverse": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-        },
-        "exit": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-        },
-        "glob": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.3.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "glob": {
-              "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "glob": {
-              "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "once": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "lodash.assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
-          "dependencies": {
-            "lodash._baseassign": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.0.2.tgz",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
-                },
-                "lodash.keys": {
-                  "version": "3.0.5",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.5.tgz",
-                  "dependencies": {
-                    "lodash.isarguments": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.1.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.1.tgz"
-                    },
-                    "lodash.isnative": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._createassigner": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.0.1.tgz",
-              "dependencies": {
-                "lodash._bindcallback": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.0.tgz"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.5",
-                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "minimatch": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "prompt": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
-          "dependencies": {
-            "pkginfo": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
-            },
-            "read": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.4",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
-                }
-              }
-            },
-            "revalidator": {
-              "version": "0.1.8",
-              "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
-            },
-            "utile": {
-              "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                },
-                "deep-equal": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
-                },
-                "i": {
-                  "version": "0.3.3",
-                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
-                },
-                "mkdirp": {
-                  "version": "0.5.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
-                "ncp": {
-                  "version": "0.4.2",
-                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
-                },
-                "rimraf": {
-                  "version": "2.3.2",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
-                  "dependencies": {
-                    "glob": {
-                      "version": "4.5.3",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "once": {
-                          "version": "1.3.1",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "winston": {
-              "version": "0.8.3",
-              "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                },
-                "colors": {
-                  "version": "0.6.2",
-                  "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
-                },
-                "cycle": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
-                },
-                "eyes": {
-                  "version": "0.1.8",
-                  "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                },
-                "stack-trace": {
-                  "version": "0.0.9",
-                  "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
-                }
-              }
-            }
-          }
-        },
-        "strip-json-comments": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-        },
-        "supports-color": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz"
-        },
-        "vow": {
-          "version": "0.4.9",
-          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.9.tgz"
-        },
-        "vow-fs": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "once": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.3",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-            },
-            "vow-queue": {
-              "version": "0.4.1",
-              "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz"
-            }
-          }
-        },
-        "xmlbuilder": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
-          "dependencies": {
-            "lodash": {
-              "version": "3.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
-            }
-          }
-        }
-      }
-    },
     "jscs-jsdoc": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-0.4.5.tgz",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-0.4.6.tgz",
       "dependencies": {
         "comment-parser": {
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.2.4.tgz"
         },
         "jsdoctypeparser": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.1.4.tgz"
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "3.8.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.8.0.tgz"
+            }
+          }
         }
       }
     },
     "load-grunt-tasks": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.1.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.2.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.2.1",
@@ -4153,8 +3159,8 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "version": "2.0.8",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
@@ -4173,8 +3179,8 @@
                   }
                 },
                 "once": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
@@ -4205,8 +3211,8 @@
               }
             },
             "minimatch": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "version": "2.0.8",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -4229,30 +3235,20 @@
       }
     },
     "morgan": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.5.2.tgz",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.5.3.tgz",
       "dependencies": {
         "basic-auth": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
-        },
-        "debug": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
-            }
-          }
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.1.tgz"
         },
         "depd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "on-finished": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
@@ -4296,13 +3292,59 @@
                 }
               }
             },
+            "glob": {
+              "version": "4.5.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.7",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
             "inherits": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "mkdirp": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
@@ -4359,8 +3401,8 @@
       }
     },
     "npm-shrinkwrap": {
-      "version": "200.1.0",
-      "resolved": "https://registry.npmjs.org/npm-shrinkwrap/-/npm-shrinkwrap-200.1.0.tgz",
+      "version": "200.4.0",
+      "resolved": "https://registry.npmjs.org/npm-shrinkwrap/-/npm-shrinkwrap-200.4.0.tgz",
       "dependencies": {
         "array-find": {
           "version": "0.1.1",
@@ -4409,8 +3451,8 @@
               "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
               "dependencies": {
                 "wordwrap": {
-                  "version": "0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
                 }
               }
             }
@@ -4489,8 +3531,8 @@
           }
         },
         "npm": {
-          "version": "2.7.5",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-2.7.5.tgz",
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-2.10.0.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
@@ -4499,6 +3541,10 @@
             "ansi": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+            },
+            "ansi-regex": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
             },
             "ansicolors": {
               "version": "0.3.2",
@@ -4524,10 +3570,6 @@
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz"
             },
-            "child-process-close": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/child-process-close/-/child-process-close-0.1.1.tgz"
-            },
             "chmodr": {
               "version": "0.1.0",
               "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
@@ -4541,26 +3583,16 @@
               "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.1.tgz"
             },
             "columnify": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.4.1.tgz",
+              "version": "1.5.1",
+              "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.1.tgz",
               "dependencies": {
-                "strip-ansi": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz"
-                    }
-                  }
-                },
                 "wcwidth": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
                   "dependencies": {
                     "defaults": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.0.tgz",
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.2.tgz",
                       "dependencies": {
                         "clone": {
                           "version": "0.1.19",
@@ -4593,8 +3625,8 @@
               }
             },
             "editor": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/editor/-/editor-0.1.0.tgz"
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz"
             },
             "fs-vacuum": {
               "version": "1.2.5",
@@ -4627,16 +3659,22 @@
               "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz"
             },
             "glob": {
-              "version": "5.0.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.3.tgz"
+              "version": "5.0.5",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.5.tgz",
+              "dependencies": {
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
             },
             "graceful-fs": {
               "version": "3.0.6",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
             },
             "hosted-git-info": {
-              "version": "1.5.3",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-1.5.3.tgz"
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.2.tgz"
             },
             "inflight": {
               "version": "1.0.4",
@@ -4651,16 +3689,32 @@
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
             },
             "init-package-json": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.3.0.tgz",
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.5.0.tgz",
               "dependencies": {
-                "glob": {
-                  "version": "4.5.3",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
-                },
                 "promzard": {
-                  "version": "0.2.2",
-                  "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.2.2.tgz"
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz"
+                },
+                "validate-npm-package-license": {
+                  "version": "1.0.0-prerelease-2",
+                  "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-1.0.0-prerelease-2.tgz",
+                  "dependencies": {
+                    "spdx-correct": {
+                      "version": "1.0.0-prerelease-3",
+                      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.0-prerelease-3.tgz"
+                    }
+                  }
+                },
+                "validate-npm-package-name": {
+                  "version": "2.2.0",
+                  "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.0.tgz",
+                  "dependencies": {
+                    "builtins": {
+                      "version": "0.0.7",
+                      "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+                    }
+                  }
                 }
               }
             },
@@ -4669,12 +3723,12 @@
               "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.0.tgz"
             },
             "lru-cache": {
-              "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+              "version": "2.6.2",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
             },
             "minimatch": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "version": "2.0.7",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
@@ -4757,8 +3811,8 @@
               "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-1.0.0.tgz"
             },
             "normalize-package-data": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz"
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.1.0.tgz"
             },
             "npm-cache-filename": {
               "version": "1.0.1",
@@ -4769,16 +3823,16 @@
               "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.5.tgz"
             },
             "npm-package-arg": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-3.1.1.tgz"
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.0.0.tgz"
             },
             "npm-registry-client": {
-              "version": "6.1.2",
-              "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-6.1.2.tgz",
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-6.3.3.tgz",
               "dependencies": {
                 "concat-stream": {
-                  "version": "1.4.7",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+                  "version": "1.4.8",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
@@ -4803,16 +3857,6 @@
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     }
                   }
-                },
-                "npm-package-arg": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-3.1.0.tgz",
-                  "dependencies": {
-                    "hosted-git-info": {
-                      "version": "1.5.3",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-1.5.3.tgz"
-                    }
-                  }
                 }
               }
             },
@@ -4825,12 +3869,30 @@
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.0.tgz",
               "dependencies": {
                 "are-we-there-yet": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.3.tgz",
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                   "dependencies": {
                     "delegates": {
                       "version": "0.1.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
                     }
                   }
                 },
@@ -4846,9 +3908,9 @@
                       "version": "3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
                     },
-                    "lodash._createpad": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/lodash._createpad/-/lodash._createpad-3.0.1.tgz",
+                    "lodash._createpadding": {
+                      "version": "3.6.0",
+                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.0.tgz",
                       "dependencies": {
                         "lodash.repeat": {
                           "version": "3.0.0",
@@ -4857,24 +3919,24 @@
                       }
                     },
                     "lodash.pad": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.0.0.tgz"
+                      "version": "3.1.0",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.0.tgz"
                     },
                     "lodash.padleft": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.0.0.tgz"
+                      "version": "3.1.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.0.tgz"
                     },
                     "lodash.padright": {
-                      "version": "3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.0.0.tgz"
+                      "version": "3.1.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.0.tgz"
                     }
                   }
                 }
               }
             },
             "once": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz"
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
             },
             "opener": {
               "version": "1.4.1",
@@ -4899,8 +3961,8 @@
               }
             },
             "read-installed": {
-              "version": "3.1.5",
-              "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-3.1.5.tgz",
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.0.tgz",
               "dependencies": {
                 "debuglog": {
                   "version": "1.0.1",
@@ -4917,13 +3979,9 @@
               }
             },
             "read-package-json": {
-              "version": "1.3.2",
-              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.3.2.tgz",
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.0.tgz",
               "dependencies": {
-                "glob": {
-                  "version": "4.5.3",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
-                },
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
                   "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
@@ -4955,12 +4013,12 @@
               }
             },
             "realize-package-specifier": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-2.2.0.tgz"
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.0.tgz"
             },
             "request": {
-              "version": "2.54.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.54.0.tgz",
+              "version": "2.55.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.5.0",
@@ -4985,8 +4043,8 @@
                   }
                 },
                 "forever-agent": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.0.tgz"
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
@@ -4999,16 +4057,12 @@
                   }
                 },
                 "har-validator": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.4.0.tgz",
+                  "version": "1.6.1",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.6.1.tgz",
                   "dependencies": {
-                    "async": {
-                      "version": "0.9.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-                    },
                     "bluebird": {
-                      "version": "2.9.15",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.15.tgz"
+                      "version": "2.9.24",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.24.tgz"
                     },
                     "chalk": {
                       "version": "1.0.0",
@@ -5026,23 +4080,9 @@
                           "version": "1.0.3",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                           "dependencies": {
-                            "ansi-regex": {
-                              "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                            },
                             "get-stdin": {
                               "version": "4.0.1",
                               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "1.1.1",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                             }
                           }
                         },
@@ -5062,27 +4102,17 @@
                         }
                       }
                     },
-                    "debug": {
-                      "version": "2.1.3",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.0",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
-                        }
-                      }
-                    },
                     "is-my-json-valid": {
-                      "version": "2.10.0",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.0.tgz",
+                      "version": "2.10.1",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.10.1.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.0.tgz",
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.1.1.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
@@ -5099,10 +4129,6 @@
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                         }
                       }
-                    },
-                    "require-directory": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.0.tgz"
                     }
                   }
                 },
@@ -5111,8 +4137,8 @@
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "boom": {
-                      "version": "2.6.1",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
+                      "version": "2.7.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
@@ -5201,8 +4227,8 @@
               "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
             },
             "rimraf": {
-              "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.3.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
@@ -5211,8 +4237,8 @@
               }
             },
             "semver": {
-              "version": "4.3.2",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz"
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
             },
             "sha": {
               "version": "1.3.0",
@@ -5246,9 +4272,23 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz"
             },
+            "spdx": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/spdx/-/spdx-0.4.0.tgz",
+              "dependencies": {
+                "spdx-license-ids": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+            },
             "tar": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.0.0.tgz"
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.1.1.tgz"
             },
             "text-table": {
               "version": "0.2.0",
@@ -5281,8 +4321,8 @@
           "resolved": "https://registry.npmjs.org/read-json/-/read-json-0.1.0.tgz"
         },
         "rimraf": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.3.tgz",
           "dependencies": {
             "glob": {
               "version": "4.5.3",
@@ -5303,8 +4343,8 @@
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "version": "2.0.7",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
@@ -5323,8 +4363,8 @@
                   }
                 },
                 "once": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
@@ -5337,8 +4377,8 @@
           }
         },
         "run-parallel": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.0.tgz",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.1.tgz",
           "dependencies": {
             "dezalgo": {
               "version": "1.0.1",
@@ -5357,8 +4397,8 @@
           }
         },
         "run-series": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.0.tgz",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.1.tgz",
           "dependencies": {
             "dezalgo": {
               "version": "1.0.1",
@@ -5385,63 +4425,19 @@
           "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz"
         },
         "string-template": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.0.tgz",
-          "dependencies": {
-            "js-string-escape": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.0.tgz"
-            }
-          }
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
         }
       }
     },
     "semver": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.5.tgz"
     },
     "time-grunt": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.1.0.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.2.1.tgz",
       "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
-        },
         "date-time": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz"
@@ -5453,6 +4449,10 @@
         "hooker": {
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "number-is-nan": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
         },
         "pretty-ms": {
           "version": "1.1.0",


### PR DESCRIPTION
[Fixes #281] Explicitly require grunt to remove NPM warnings over peer dependencies. I know this is one of those simple and stupid things, I just think removing the warnings should speed up build times (even very slightly). Over time it should add up to some savings.