### PR TITLE
README: add badge indicating current development status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![NPM version](https://badge.fury.io/js/bootlint.svg)](http://badge.fury.io/js/bootlint)
 [![Build Status](https://img.shields.io/travis/twbs/bootlint/master.svg)](https://travis-ci.org/twbs/bootlint)
 [![Coverage Status](https://img.shields.io/coveralls/twbs/bootlint.svg?branch=master)](https://coveralls.io/r/twbs/bootlint)
+![Development Status :: 5 - Production/Stable](https://img.shields.io/badge/maturity-stable-green.svg "Development Status :: 5 - Production/Stable")
 [![MIT License](https://img.shields.io/github/license/twbs/bootlint.svg)](https://github.com/twbs/bootlint/blob/master/LICENSE)
 [![Dependency Status](https://david-dm.org/twbs/bootlint.svg)](https://david-dm.org/twbs/bootlint)
 [![devDependency Status](https://david-dm.org/twbs/bootlint/dev-status.svg)](https://david-dm.org/twbs/bootlint#info=devDependencies)


### PR DESCRIPTION
This adds a badge to, at a glance, indicate the project's current development status to folks who are considering whether to use it.
IMO, we are definitely beyond `Development Status :: 4 - Beta`; the core APIs are stable, we include a good number of lint checkers, and the project is adequately suited to production usage by our end-users.
I hesitate against `Development Status :: 6 - Mature` due to the relative youth of the project and out of conservatism (better to under-promise and over-deliver than vice-versa).

Refs: http://producingoss.com/en/getting-started.html#development-status
Compare: https://nodejs.org/api/documentation.html#documentation_stability_index

CC: @hnrch02 for review