### PR TITLE
Warn about button.disabled

### DIFF
--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -1064,7 +1064,13 @@ var LocationIndex = _location.LocationIndex;
             }
         });
     });
+    addLinter("W016", function lintNavbarContainers($, reporter) {
+        var disabledBtn = $('button.disabled');
 
+        if (disabledBtn.length) {
+            reporter("The `.disabled` class on a `button` doesn't disable button features like click and focus. Use the `disabled` attribute, instead.", disabledBtn);
+        }
+    });
     exports._lint = function ($, reporter, disabledIdList, html) {
         var locationIndex = IN_NODE_JS ? new LocationIndex(html) : null;
         var reporterWrapper = IN_NODE_JS ? function (problem) {

--- a/test/README.md
+++ b/test/README.md
@@ -5,7 +5,7 @@
 
 To test usage in a Node.js environment, [Nodeunit](https://github.com/caolan/nodeunit) tests are defined in `/test/bootlint_test.js`, and can be run via the `nodeunit` Grunt task.
 
-To test usage in a browser environment, we use [QUnit](http://qunitjs.com) along with some additional automation in `/test/fixtures/generic-qunit.js`. Basically, when PhantomJS runs each test case webpage, we automatically Bootlint the page and then assert that the list of lint messages equals the `data-lint` attributes of the `<li>`s under the `<ol id="bootlint">` within the page. The `qunit` Grunt task runs these tests in PhantomJS.
+To test usage in a browser environment, we use [QUnit](http://qunitjs.com) along with some additional automation in `/test/fixtures/generic-qunit.js`. Basically, when PhantomJS runs each test case webpage, we automatically Bootlint the page and then assert that the list of lint messages equals the `data-lint` attributes of the `<li>`s under the `<ol id="bootlint">` within the page. To disable other lints in your tests, add `data-disabled` attributes to `li`s. The `qunit` Grunt task runs these tests in PhantomJS.
 
 
 ## How do I add a new test?

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -228,7 +228,7 @@ exports.bootlint = {
     },
     'tooltips and popovers on disabled elements': function (test) {
         test.expect(1);
-        test.deepEqual(lintHtml(utf8Fixture('tooltips/on-disabled-elems.html')),
+        test.deepEqual(lintHtml(utf8Fixture('tooltips/on-disabled-elems.html'), ['W016']),
             ["Tooltips and popovers on disabled elements cannot be triggered by user interaction unless the element becomes enabled." +
             " To have tooltips and popovers be triggerable by the user even when their associated element is disabled," +
             " put the disabled element inside a wrapper `<div>` and apply the tooltip or popover to the wrapper `<div>` instead."],
@@ -327,6 +327,16 @@ exports.bootlint = {
         test.deepEqual(lintHtml(utf8Fixture('buttons/with-type.html')),
             [],
             'should not complain when type is set on buttons');
+        test.done();
+    },
+    'use disabled attribute on button.btn instead of .disabled': function (test) {
+        test.expect(2);
+        test.deepEqual(lintHtml(utf8Fixture('buttons/disabled-class.html')),
+            ["The `.disabled` class on a `button` doesn't disable button features like click and focus. Use the `disabled` attribute, instead."],
+            'should complain when Bootstrap v2 grid classes are present.');
+        test.deepEqual(lintHtml(utf8Fixture('buttons/disabled-attribute.html')),
+            [],
+            'should not complain when disabled attribute is set on buttons');
         test.done();
     },
     'incorrect markup for .checkbox, .radio, .checkbox-inline, and .radio-inline classes': function (test) {

--- a/test/fixtures/buttons/disabled-attribute.html
+++ b/test/fixtures/buttons/disabled-attribute.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Test</title>
+        <!--[if lt IE 9]>
+            <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+            <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+        <script src="../../lib/jquery.min.js"></script>
+
+        <link rel="stylesheet" href="../../lib/qunit.css">
+        <script src="../../lib/qunit.js"></script>
+        <script src="../../../dist/browser/bootlint.js"></script>
+        <script src="../generic-qunit.js"></script>
+    </head>
+    <body>
+
+        <button type="button" disabled>Mash</button>
+
+        <div id="qunit"></div>
+        <ol id="bootlint"></ol>
+    </body>
+</html>
+

--- a/test/fixtures/buttons/disabled-class.html
+++ b/test/fixtures/buttons/disabled-class.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Test</title>
+        <!--[if lt IE 9]>
+            <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+            <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+        <script src="../../lib/jquery.min.js"></script>
+
+        <link rel="stylesheet" href="../../lib/qunit.css">
+        <script src="../../lib/qunit.js"></script>
+        <script src="../../../dist/browser/bootlint.js"></script>
+        <script src="../generic-qunit.js"></script>
+    </head>
+    <body>
+
+        <button type="button" class="disabled">Mash</button>
+
+        <div id="qunit"></div>
+        <ol id="bootlint">
+          <li data-lint="The `.disabled` class on a `button` doesn't disable button features like click and focus. Use the `disabled` attribute, instead."></li>
+        </ol>
+    </body>
+</html>
+

--- a/test/fixtures/generic-qunit.js
+++ b/test/fixtures/generic-qunit.js
@@ -5,22 +5,29 @@
 (function () {
     'use strict';
 
-    function lintCurrentDoc() {
+    function lintCurrentDoc(disabledIds) {
         var lints = [];
         var reporter = function (lint) {
             lints.push(lint.message);
         };
-        bootlint.lintCurrentDocument(reporter, []);
+        bootlint.lintCurrentDocument(reporter, disabledIds);
         return lints;
     }
 
     QUnit.test(window.location.pathname, function (assert) {
         expect(1);
         var lints = Array.prototype.slice.call(document.querySelectorAll('#bootlint>li'));
-        var expectedLintMsgs = lints.map(function (item) {
+        var expectedLintMsgs = lints.filter(function (item) {
+            return typeof item.dataset.lint === 'string';
+        }).map(function (item) {
             return item.dataset.lint;
         });
-        var actualLintMsgs = lintCurrentDoc();
+        var disabledIds = lints.filter(function (item) {
+            return typeof item.dataset.disabled === 'string';
+        }).map(function (item) {
+            return item.dataset.disabled;
+        });
+        var actualLintMsgs = lintCurrentDoc(disabledIds);
         assert.deepEqual(actualLintMsgs, expectedLintMsgs);
     });
 })();

--- a/test/fixtures/tooltips/on-disabled-elems.html
+++ b/test/fixtures/tooltips/on-disabled-elems.html
@@ -24,7 +24,7 @@
 
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="Tooltips and popovers on disabled elements cannot be triggered by user interaction unless the element becomes enabled. To have tooltips and popovers be triggerable by the user even when their associated element is disabled, put the disabled element inside a wrapper `&lt;div&gt;` and apply the tooltip or popover to the wrapper `&lt;div&gt;` instead."></li>
+            <li data-lint="Tooltips and popovers on disabled elements cannot be triggered by user interaction unless the element becomes enabled. To have tooltips and popovers be triggerable by the user even when their associated element is disabled, put the disabled element inside a wrapper `&lt;div&gt;` and apply the tooltip or popover to the wrapper `&lt;div&gt;` instead." data-disabled="W016"></li>
         </ol>
     </body>
 </html>


### PR DESCRIPTION
Fixes #293 

W006 causes some conflicts here in the unit tests because on-disabled-elems.html specifically puts `.disabled` on button elements, so they also now report this new warning about `.disabled` on a `<button>`. 

In nodeunit, I can just pass `['W006']` and `['W016']` (the new warning for this one) as disabledIds in each respective unit test, but disabledIds weren't set up for qunit, so I added `data-disabled` as an attribute.

This isn't a case that comes up often, so maybe there's a better approach here. Maybe this is overkill and we simply remove the two lines from on-disabled-elems.html that use buttons. Thoughts?

cc @cvrebert @hnrch02 for review.