### PR TITLE
Bump CURRENT_BOOTSTRAP_VERSION to 3.3.6

### DIFF
--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -35,7 +35,7 @@ var LocationIndex = _location.LocationIndex;
     var NUM2SCREEN = ['xs', 'sm', 'md', 'lg'];
     var IN_NODE_JS = !!(cheerio.load);
     var MIN_JQUERY_VERSION = '1.9.1';// as of Bootstrap v3.3.0
-    var CURRENT_BOOTSTRAP_VERSION = '3.3.5';
+    var CURRENT_BOOTSTRAP_VERSION = '3.3.6';
     var BOOTSTRAP_VERSION_4 = '4.0.0';
     var PLUGINS = [
         'affix',

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -682,16 +682,16 @@ exports.bootlint = {
     'outdated version of Bootstrap': function (test) {
         test.expect(5);
         test.deepEqual(lintHtml(utf8Fixture('outdated/bootstrap-css.html')),
-            ['Bootstrap version might be outdated. Latest version is at least 3.3.5 ; saw what appears to be usage of Bootstrap 3.2.0'],
+            ['Bootstrap version might be outdated. Latest version is at least 3.3.6 ; saw what appears to be usage of Bootstrap 3.2.0'],
             'should complain about outdated bootstrap.css.');
         test.deepEqual(lintHtml(utf8Fixture('outdated/bootstrap-min-css.html')),
-            ['Bootstrap version might be outdated. Latest version is at least 3.3.5 ; saw what appears to be usage of Bootstrap 3.2.0'],
+            ['Bootstrap version might be outdated. Latest version is at least 3.3.6 ; saw what appears to be usage of Bootstrap 3.2.0'],
             'should complain about outdated bootstrap.min.css.');
         test.deepEqual(lintHtml(utf8Fixture('outdated/bootstrap-js.html')),
-            ['Bootstrap version might be outdated. Latest version is at least 3.3.5 ; saw what appears to be usage of Bootstrap 3.2.0'],
+            ['Bootstrap version might be outdated. Latest version is at least 3.3.6 ; saw what appears to be usage of Bootstrap 3.2.0'],
             'should complain about outdated bootstrap.js.');
         test.deepEqual(lintHtml(utf8Fixture('outdated/bootstrap-min-js.html')),
-            ['Bootstrap version might be outdated. Latest version is at least 3.3.5 ; saw what appears to be usage of Bootstrap 3.2.0'],
+            ['Bootstrap version might be outdated. Latest version is at least 3.3.6 ; saw what appears to be usage of Bootstrap 3.2.0'],
             'should complain about outdated bootstrap.min.js.');
         test.deepEqual(lintHtml(utf8Fixture('outdated/bootstrap-extensions-okay.html')),
             [],

--- a/test/fixtures/outdated/bootstrap-css.html
+++ b/test/fixtures/outdated/bootstrap-css.html
@@ -20,7 +20,7 @@
     <body>
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="Bootstrap version might be outdated. Latest version is at least 3.3.5 ; saw what appears to be usage of Bootstrap 3.2.0"></li>
+            <li data-lint="Bootstrap version might be outdated. Latest version is at least 3.3.6 ; saw what appears to be usage of Bootstrap 3.2.0"></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/outdated/bootstrap-js.html
+++ b/test/fixtures/outdated/bootstrap-js.html
@@ -20,7 +20,7 @@
     <body>
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="Bootstrap version might be outdated. Latest version is at least 3.3.5 ; saw what appears to be usage of Bootstrap 3.2.0"></li>
+            <li data-lint="Bootstrap version might be outdated. Latest version is at least 3.3.6 ; saw what appears to be usage of Bootstrap 3.2.0"></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/outdated/bootstrap-min-css.html
+++ b/test/fixtures/outdated/bootstrap-min-css.html
@@ -20,7 +20,7 @@
     <body>
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="Bootstrap version might be outdated. Latest version is at least 3.3.5 ; saw what appears to be usage of Bootstrap 3.2.0"></li>
+            <li data-lint="Bootstrap version might be outdated. Latest version is at least 3.3.6 ; saw what appears to be usage of Bootstrap 3.2.0"></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/outdated/bootstrap-min-js.html
+++ b/test/fixtures/outdated/bootstrap-min-js.html
@@ -20,7 +20,7 @@
     <body>
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="Bootstrap version might be outdated. Latest version is at least 3.3.5 ; saw what appears to be usage of Bootstrap 3.2.0"></li>
+            <li data-lint="Bootstrap version might be outdated. Latest version is at least 3.3.6 ; saw what appears to be usage of Bootstrap 3.2.0"></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/outdated/js-version-not-in-url-current.html
+++ b/test/fixtures/outdated/js-version-not-in-url-current.html
@@ -12,7 +12,7 @@
         <script src="../../lib/jquery.min.js"></script>
         <script>
         (function () {
-            window.$.fn.modal = { Constructor: { VERSION: '3.3.5' } };
+            window.$.fn.modal = { Constructor: { VERSION: '3.3.6' } };
         })();
         </script>
 

--- a/test/fixtures/outdated/js-version-not-in-url-outdated.html
+++ b/test/fixtures/outdated/js-version-not-in-url-outdated.html
@@ -24,7 +24,7 @@
     <body>
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="Bootstrap version might be outdated. Latest version is at least 3.3.5 ; saw what appears to be usage of Bootstrap 3.2.0"></li>
+            <li data-lint="Bootstrap version might be outdated. Latest version is at least 3.3.6 ; saw what appears to be usage of Bootstrap 3.2.0"></li>
         </ol>
     </body>
 </html>


### PR DESCRIPTION
Refs http://blog.getbootstrap.com/2015/11/24/bootstrap-3-3-6-released/