### PR TITLE
Feature/318 modal role dialog

### DIFF
--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -1082,6 +1082,12 @@ var LocationIndex = _location.LocationIndex;
             reporter('`.btn` should only be used on `<a>`, `<button>`, `<input>`, or `<label>` elements.', btns);
         }
     });
+    addLinter("E048", function lintModalRole($, reporter) {
+        var modals = $('.modal:not([role=dialog])');
+        if (modals.length) {
+            reporter('`.modal` should always have a `role` attribute with a value of `dialog`.', modals);
+        }
+    });
     exports._lint = function ($, reporter, disabledIdList, html) {
         var locationIndex = IN_NODE_JS ? new LocationIndex(html) : null;
         var reporterWrapper = IN_NODE_JS ? function (problem) {

--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -1083,9 +1083,9 @@ var LocationIndex = _location.LocationIndex;
         }
     });
     addLinter("E048", function lintModalRole($, reporter) {
-        var modals = $('.modal:not([role=dialog])');
+        var modals = $('.modal:not([role="dialog"])');
         if (modals.length) {
-            reporter('`.modal` should always have a `role` attribute with a value of `dialog`.', modals);
+            reporter('`.modal` must have a `role="dialog"` attribute.', modals);
         }
     });
     exports._lint = function ($, reporter, disabledIdList, html) {

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -921,5 +921,13 @@ exports.bootlint = {
             'should not complain about `.btn` on an <a>, <button>, <input>, or <label>.'
         );
         test.done();
+    },
+    'modal missing role dialog': function (test) {
+        test.expect(1);
+        test.deepEqual(lintHtml(utf8Fixture('modal/missing-role-dialog.html')),
+            ['`.modal` must have a `role="dialog"` attribute.'],
+            'should complain about modal missing a `role` attribute.'
+        );
+        test.done();
     }
 };

--- a/test/fixtures/modal/body-outside-content.html
+++ b/test/fixtures/modal/body-outside-content.html
@@ -17,7 +17,7 @@
         <script src="../generic-qunit.js"></script>
     </head>
     <body>
-        <div class="modal fade" tabindex="-1">
+        <div class="modal fade" tabindex="-1" role="dialog">
             <div class="modal-dialog">
                 <!--Oops, forgot about the div.modal-content-->
                 <div class="modal-body">

--- a/test/fixtures/modal/content-outside-dialog.html
+++ b/test/fixtures/modal/content-outside-dialog.html
@@ -17,7 +17,7 @@
         <script src="../generic-qunit.js"></script>
     </head>
     <body>
-        <div class="modal fade" tabindex="-1">
+        <div class="modal fade" tabindex="-1" role="dialog">
             <!--Oops, forgot about the .modal-dialog-->
             <div class="modal-content">
                 <div class="modal-header">

--- a/test/fixtures/modal/footer-outside-content.html
+++ b/test/fixtures/modal/footer-outside-content.html
@@ -17,7 +17,7 @@
         <script src="../generic-qunit.js"></script>
     </head>
     <body>
-        <div class="modal fade" tabindex="-1">
+        <div class="modal fade" tabindex="-1" role="dialog">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">

--- a/test/fixtures/modal/header-outside-content.html
+++ b/test/fixtures/modal/header-outside-content.html
@@ -17,7 +17,7 @@
         <script src="../generic-qunit.js"></script>
     </head>
     <body>
-        <div class="modal fade" tabindex="-1">
+        <div class="modal fade" tabindex="-1" role="dialog">
             <div class="modal-dialog">
                 <!--Oops, the .modal-header ought to be within the .modal-content-->
                 <div class="modal-header">

--- a/test/fixtures/modal/missing-role-dialog.html
+++ b/test/fixtures/modal/missing-role-dialog.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Test</title>
+        <!--[if lt IE 9]>
+            <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+            <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+        <script src="../../lib/jquery.min.js"></script>
+
+        <link rel="stylesheet" href="../../lib/qunit.css">
+        <script src="../../lib/qunit.js"></script>
+        <script src="../../../dist/browser/bootlint.js"></script>
+        <script src="../generic-qunit.js"></script>
+    </head>
+    <body>
+        <div class="modal fade" tabindex="-1">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                        <h4 class="modal-title">Modal title</h4>
+                    </div>
+                    <div class="modal-body">
+                        <p>One fine body&hellip;</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-primary">Save changes</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div id="qunit"></div>
+        <ol id="bootlint">
+            <li data-lint="`.modal` should always have a `role` attribute with a value of `dialog`."></li>
+        </ol>
+    </body>
+</html>

--- a/test/fixtures/modal/missing-role-dialog.html
+++ b/test/fixtures/modal/missing-role-dialog.html
@@ -37,7 +37,7 @@
 
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="`.modal` should always have a `role` attribute with a value of `dialog`."></li>
+            <li data-lint="`.modal` must have a `role=&quot;dialog&quot;` attribute."></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/modal/tabindex-missing.html
+++ b/test/fixtures/modal/tabindex-missing.html
@@ -17,7 +17,7 @@
         <script src="../generic-qunit.js"></script>
     </head>
     <body>
-        <div class="modal fade">
+        <div class="modal fade" role="dialog">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">

--- a/test/fixtures/modal/title-outside-header.html
+++ b/test/fixtures/modal/title-outside-header.html
@@ -17,7 +17,7 @@
         <script src="../generic-qunit.js"></script>
     </head>
     <body>
-        <div class="modal fade" tabindex="-1">
+        <div class="modal fade" tabindex="-1" role="dialog">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <h4 class="modal-title">Modal title but I should be inside a modal header</h4>

--- a/test/fixtures/modal/valid.html
+++ b/test/fixtures/modal/valid.html
@@ -17,7 +17,7 @@
         <script src="../generic-qunit.js"></script>
     </head>
     <body>
-        <div class="modal fade" tabindex="-1">
+        <div class="modal fade" tabindex="-1" role="dialog">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">

--- a/test/fixtures/modal/with-hide.html
+++ b/test/fixtures/modal/with-hide.html
@@ -17,7 +17,7 @@
         <script src="../generic-qunit.js"></script>
     </head>
     <body>
-        <div class="modal hide" tabindex="-1">
+        <div class="modal hide" tabindex="-1" role="dialog">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">

--- a/test/fixtures/modal/within-navbar.html
+++ b/test/fixtures/modal/within-navbar.html
@@ -20,7 +20,7 @@
       <nav class="navbar navbar-default" role="navigation">
         <div class="container-fluid">
           <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal">Open ze modal!</button>
-          <div class="modal fade" id="myModal" tabindex="-1">
+          <div class="modal fade" id="myModal" tabindex="-1" role="dialog">
               <div class="modal-dialog">
                   <div class="modal-content">
                       <div class="modal-header">

--- a/test/fixtures/modal/within-table.html
+++ b/test/fixtures/modal/within-table.html
@@ -23,7 +23,7 @@
                     <td>One cell</td>
                     <td>
                         <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal">Open ze modal!</button>
-                        <div class="modal fade" id="myModal" tabindex="-1">
+                        <div class="modal fade" id="myModal" tabindex="-1" role="dialog">
                             <div class="modal-dialog">
                                 <div class="modal-content">
                                     <div class="modal-header">


### PR DESCRIPTION
I added a new error, E048, to address ticket #318. All existing fixtures have been updated to include `role="dialog"`. A new test fixture has been added to ensure the new error is triggered if `role="dialog"` is forgotten.