### PR TITLE
Feature/319 modal dialog role

### DIFF
--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -1088,6 +1088,12 @@ var LocationIndex = _location.LocationIndex;
             reporter('`.modal` must have a `role="dialog"` attribute.', modals);
         }
     });
+    addLinter("E049", function lintModalDialogRole($, reporter) {
+        var modalDialogs = $('.modal-dialog:not([role="document"])');
+        if (modalDialogs.length) {
+            reporter('`.modal-dialog` must have a `role="document"` attribute.', modalDialogs);
+        }
+    });
     exports._lint = function ($, reporter, disabledIdList, html) {
         var locationIndex = IN_NODE_JS ? new LocationIndex(html) : null;
         var reporterWrapper = IN_NODE_JS ? function (problem) {

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -929,5 +929,13 @@ exports.bootlint = {
             'should complain about modal missing a `role` attribute.'
         );
         test.done();
+    },
+    'modal-dialog missing role document': function (test) {
+        test.expect(1);
+        test.deepEqual(lintHtml(utf8Fixture('modal/missing-role-document.html')),
+            ['`.modal-dialog` must have a `role="document"` attribute.'],
+            'should complain about modal-dialog missing a `role` attribute.'
+        );
+        test.done();
     }
 };

--- a/test/fixtures/modal/body-outside-content.html
+++ b/test/fixtures/modal/body-outside-content.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <div class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog">
+            <div class="modal-dialog" role="document">
                 <!--Oops, forgot about the div.modal-content-->
                 <div class="modal-body">
                     <p>One fine body&hellip;</p>

--- a/test/fixtures/modal/dialog-outside-modal.html
+++ b/test/fixtures/modal/dialog-outside-modal.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <!--Oops, forgot the div.modal wrapper...-->
-        <div class="modal-dialog">
+        <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/test/fixtures/modal/footer-outside-content.html
+++ b/test/fixtures/modal/footer-outside-content.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <div class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog">
+            <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/test/fixtures/modal/header-outside-content.html
+++ b/test/fixtures/modal/header-outside-content.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <div class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog">
+            <div class="modal-dialog" role="document">
                 <!--Oops, the .modal-header ought to be within the .modal-content-->
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/test/fixtures/modal/missing-role-dialog.html
+++ b/test/fixtures/modal/missing-role-dialog.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <div class="modal fade" tabindex="-1">
-            <div class="modal-dialog">
+            <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/test/fixtures/modal/missing-role-document.html
+++ b/test/fixtures/modal/missing-role-document.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Test</title>
+        <!--[if lt IE 9]>
+            <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+            <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+        <script src="../../lib/jquery.min.js"></script>
+
+        <link rel="stylesheet" href="../../lib/qunit.css">
+        <script src="../../lib/qunit.js"></script>
+        <script src="../../../dist/browser/bootlint.js"></script>
+        <script src="../generic-qunit.js"></script>
+    </head>
+    <body>
+        <div class="modal fade" tabindex="-1" role="dialog">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                        <h4 class="modal-title">Modal title</h4>
+                    </div>
+                    <div class="modal-body">
+                        <p>One fine body&hellip;</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-primary">Save changes</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div id="qunit"></div>
+        <ol id="bootlint">
+            <li data-lint="`.modal-dialog` must have a `role=&quot;document&quot;` attribute."></li>
+        </ol>
+    </body>
+</html>

--- a/test/fixtures/modal/tabindex-missing.html
+++ b/test/fixtures/modal/tabindex-missing.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <div class="modal fade" role="dialog">
-            <div class="modal-dialog">
+            <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/test/fixtures/modal/title-outside-header.html
+++ b/test/fixtures/modal/title-outside-header.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <div class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog">
+            <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <h4 class="modal-title">Modal title but I should be inside a modal header</h4>
                     <div class="modal-body">

--- a/test/fixtures/modal/valid.html
+++ b/test/fixtures/modal/valid.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <div class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog">
+            <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/test/fixtures/modal/with-hide.html
+++ b/test/fixtures/modal/with-hide.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <div class="modal hide" tabindex="-1" role="dialog">
-            <div class="modal-dialog">
+            <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/test/fixtures/modal/within-navbar.html
+++ b/test/fixtures/modal/within-navbar.html
@@ -21,7 +21,7 @@
         <div class="container-fluid">
           <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal">Open ze modal!</button>
           <div class="modal fade" id="myModal" tabindex="-1" role="dialog">
-              <div class="modal-dialog">
+              <div class="modal-dialog" role="document">
                   <div class="modal-content">
                       <div class="modal-header">
                           <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>

--- a/test/fixtures/modal/within-table.html
+++ b/test/fixtures/modal/within-table.html
@@ -24,7 +24,7 @@
                     <td>
                         <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal">Open ze modal!</button>
                         <div class="modal fade" id="myModal" tabindex="-1" role="dialog">
-                            <div class="modal-dialog">
+                            <div class="modal-dialog" role="document">
                                 <div class="modal-content">
                                     <div class="modal-header">
                                         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>


### PR DESCRIPTION
I added a new error, E049, to address ticket #319. All existing fixtures have been updated to include role="document". A new test fixture has been added to ensure the new error is triggered if role="document" is forgotten for `.modal-dialog`. bootlint_test has been updated too. 