### PR TITLE
Feature/341 inputs without type attr

### DIFF
--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -578,6 +578,12 @@ var LocationIndex = _location.LocationIndex;
             reporter("Using the `.disabled` class on a `<button>` or `<input>` only changes the appearance of the element. It doesn't prevent the user from interacting with the element (for example, clicking on it or focusing it). If you want to truly disable the element, use the `disabled` attribute instead.", btnsWithDisabledClass);
         }
     });
+    addLinter("W017", function lintInputsMissingTypeAttr($, reporter) {
+        var inputsMissingTypeAttr = $('input:not([type])');
+        if (inputsMissingTypeAttr.length) {
+            reporter("Found one or more `<input>`s missing a `type` attribute.", inputsMissingTypeAttr);
+        }
+    });
 
     addLinter("E001", (function () {
         var MISSING_DOCTYPE = "Document is missing a DOCTYPE declaration";

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -345,6 +345,16 @@ exports.bootlint = {
             'should not complain when disabled attribute is set on buttons');
         test.done();
     },
+    'inputs should set type': function (test) {
+        test.expect(2);
+        test.deepEqual(lintHtml(utf8Fixture('form-control/without-type.html')),
+            ["Found one or more `<input>`s missing a `type` attribute."],
+            'should complain about lack of type attribute on inputs');
+        test.deepEqual(lintHtml(utf8Fixture('form-control/with-type.html')),
+            [],
+            'should not complain when type is set on inputs');
+        test.done();
+    },
     'incorrect markup for .checkbox, .radio, .checkbox-inline, and .radio-inline classes': function (test) {
         test.expect(7);
 

--- a/test/fixtures/form-control/with-type.html
+++ b/test/fixtures/form-control/with-type.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Test</title>
+        <!--[if lt IE 9]>
+            <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+            <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+        <script src="../../lib/jquery.min.js"></script>
+
+        <link rel="stylesheet" href="../../lib/qunit.css">
+        <script src="../../lib/qunit.js"></script>
+        <script src="../../../dist/browser/bootlint.js"></script>
+        <script src="../generic-qunit.js"></script>
+    </head>
+    <body>
+        <input type="text" class="form-control" />
+
+        <div id="qunit"></div>
+        <ol id="bootlint"></ol>
+    </body>
+</html>

--- a/test/fixtures/form-control/without-type.html
+++ b/test/fixtures/form-control/without-type.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Test</title>
+        <!--[if lt IE 9]>
+            <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+            <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+        <script src="../../lib/jquery.min.js"></script>
+
+        <link rel="stylesheet" href="../../lib/qunit.css">
+        <script src="../../lib/qunit.js"></script>
+        <script src="../../../dist/browser/bootlint.js"></script>
+        <script src="../generic-qunit.js"></script>
+    </head>
+    <body>
+        <input />
+
+        <div id="qunit"></div>
+        <ol id="bootlint">
+          <li data-lint="Found one or more `<input>`s missing a `type` attribute."></li>
+        </ol>
+    </body>
+</html>


### PR DESCRIPTION
I added a new warning, W017, to address ticket #341. Two new test fixtures have been added to ensure the new warning triggers if `type` is missing and doesn't trigger if the `type` attribute is present. bootlint_test has been updated too.