### PR TITLE
Use backticks around CSS selectors in lint messages.

### DIFF
--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -767,7 +767,7 @@ var LocationIndex = _location.LocationIndex;
             return $(div).filter(':has(>label>input[type="checkbox"])').length <= 0;
         });
         if (badCheckboxes.length) {
-            reporter('Incorrect markup used with the `.checkbox` class. The correct markup structure is .checkbox>label>input[type="checkbox"]', badCheckboxes);
+            reporter('Incorrect markup used with the `.checkbox` class. The correct markup structure is `.checkbox>label>input[type="checkbox"]`', badCheckboxes);
         }
     });
     addLinter("E018", function lintBlockRadios($, reporter) {
@@ -775,7 +775,7 @@ var LocationIndex = _location.LocationIndex;
             return $(div).filter(':has(>label>input[type="radio"])').length <= 0;
         });
         if (badRadios.length) {
-            reporter('Incorrect markup used with the `.radio` class. The correct markup structure is .radio>label>input[type="radio"]', badRadios);
+            reporter('Incorrect markup used with the `.radio` class. The correct markup structure is `.radio>label>input[type="radio"]`', badRadios);
         }
     });
     addLinter("E019", function lintInlineCheckboxes($, reporter) {
@@ -787,7 +787,7 @@ var LocationIndex = _location.LocationIndex;
             return $(label).children('input[type="checkbox"]').length <= 0;
         });
         if (badStructures.length) {
-            reporter('Incorrect markup used with the `.checkbox-inline` class. The correct markup structure is label.checkbox-inline>input[type="checkbox"]', badStructures);
+            reporter('Incorrect markup used with the `.checkbox-inline` class. The correct markup structure is `label.checkbox-inline>input[type="checkbox"]`', badStructures);
         }
     });
     addLinter("E020", function lintInlineRadios($, reporter) {
@@ -799,7 +799,7 @@ var LocationIndex = _location.LocationIndex;
             return $(label).children('input[type="radio"]').length <= 0;
         });
         if (badStructures.length) {
-            reporter('Incorrect markup used with the `.radio-inline` class. The correct markup structure is label.radio-inline>input[type="radio"]', badStructures);
+            reporter('Incorrect markup used with the `.radio-inline` class. The correct markup structure is `label.radio-inline>input[type="radio"]`', badStructures);
         }
     });
     addLinter("E021", function lintButtonsCheckedActive($, reporter) {

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -363,10 +363,10 @@ exports.bootlint = {
             'should not complain when correct radio and checkbox markup is used.');
 
         test.deepEqual(lintHtml(utf8Fixture('checkboxes-radios/checkbox-block-bad.html')),
-            ['Incorrect markup used with the `.checkbox` class. The correct markup structure is .checkbox>label>input[type="checkbox"]'],
+            ['Incorrect markup used with the `.checkbox` class. The correct markup structure is `.checkbox>label>input[type="checkbox"]`'],
             'should complain when invalid .checkbox markup is used.');
         test.deepEqual(lintHtml(utf8Fixture('checkboxes-radios/radio-block-bad.html')),
-            ['Incorrect markup used with the `.radio` class. The correct markup structure is .radio>label>input[type="radio"]'],
+            ['Incorrect markup used with the `.radio` class. The correct markup structure is `.radio>label>input[type="radio"]`'],
             'should complain when invalid .radio markup is used.');
 
         test.deepEqual(lintHtml(utf8Fixture('checkboxes-radios/checkbox-inline-non-label.html')),
@@ -377,10 +377,10 @@ exports.bootlint = {
             'should complain when .radio-inline is used on a non-<label> element.');
 
         test.deepEqual(lintHtml(utf8Fixture('checkboxes-radios/checkbox-inline-bad-structure.html')),
-            ['Incorrect markup used with the `.checkbox-inline` class. The correct markup structure is label.checkbox-inline>input[type="checkbox"]'],
+            ['Incorrect markup used with the `.checkbox-inline` class. The correct markup structure is `label.checkbox-inline>input[type="checkbox"]`'],
             'should complain when invalid .checkbox-inline markup is used.');
         test.deepEqual(lintHtml(utf8Fixture('checkboxes-radios/radio-inline-bad-structure.html')),
-            ['Incorrect markup used with the `.radio-inline` class. The correct markup structure is label.radio-inline>input[type="radio"]'],
+            ['Incorrect markup used with the `.radio-inline` class. The correct markup structure is `label.radio-inline>input[type="radio"]`'],
             'should complain when invalid .radio-inline markup is used.');
 
         test.done();

--- a/test/fixtures/checkboxes-radios/checkbox-block-bad.html
+++ b/test/fixtures/checkboxes-radios/checkbox-block-bad.html
@@ -26,7 +26,7 @@
 
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="Incorrect markup used with the `.checkbox` class. The correct markup structure is .checkbox&gt;label&gt;input[type=&quot;checkbox&quot;]"></li>
+            <li data-lint="Incorrect markup used with the `.checkbox` class. The correct markup structure is `.checkbox&gt;label&gt;input[type=&quot;checkbox&quot;]`"></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/checkboxes-radios/checkbox-inline-bad-structure.html
+++ b/test/fixtures/checkboxes-radios/checkbox-inline-bad-structure.html
@@ -26,7 +26,7 @@
 
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="Incorrect markup used with the `.checkbox-inline` class. The correct markup structure is label.checkbox-inline&gt;input[type=&quot;checkbox&quot;]"></li>
+            <li data-lint="Incorrect markup used with the `.checkbox-inline` class. The correct markup structure is `label.checkbox-inline&gt;input[type=&quot;checkbox&quot;]`"></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/checkboxes-radios/radio-block-bad.html
+++ b/test/fixtures/checkboxes-radios/radio-block-bad.html
@@ -26,7 +26,7 @@
 
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="Incorrect markup used with the `.radio` class. The correct markup structure is .radio&gt;label&gt;input[type=&quot;radio&quot;]"></li>
+            <li data-lint="Incorrect markup used with the `.radio` class. The correct markup structure is `.radio&gt;label&gt;input[type=&quot;radio&quot;]`"></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/checkboxes-radios/radio-inline-bad-structure.html
+++ b/test/fixtures/checkboxes-radios/radio-inline-bad-structure.html
@@ -26,7 +26,7 @@
 
         <div id="qunit"></div>
         <ol id="bootlint">
-            <li data-lint="Incorrect markup used with the `.radio-inline` class. The correct markup structure is label.radio-inline&gt;input[type=&quot;radio&quot;]"></li>
+            <li data-lint="Incorrect markup used with the `.radio-inline` class. The correct markup structure is `label.radio-inline&gt;input[type=&quot;radio&quot;]`"></li>
         </ol>
     </body>
 </html>


### PR DESCRIPTION
Fixes #340.

/CC @cvrebert 