### PR TITLE
Adapt for input group changes

### DIFF
--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -731,35 +731,21 @@ var LocationIndex = _location.LocationIndex;
     addLinter('E009', function lintMissingInputGroupSizes($, reporter) {
         var selector = [
             '.input-group:not(.input-group-lg) .btn-lg',
-            '.input-group:not(.input-group-lg) .input-lg',
+            '.input-group:not(.input-group-lg) .form-control-lg',
             '.input-group:not(.input-group-sm) .btn-sm',
-            '.input-group:not(.input-group-sm) .input-sm'
+            '.input-group:not(.input-group-sm) .form-control-sm'
         ].join(',');
         var badInputGroupSizing = $(selector);
         if (badInputGroupSizing.length) {
             reporter('Button and input sizing within `.input-group`s can cause issues. Instead, use input group sizing classes `.input-group-lg` or `.input-group-sm`', badInputGroupSizing);
         }
     });
-    */
-    /*
-    addLinter('E010', function lintMultipleFormControlsInInputGroup($, reporter) {
-        var badInputGroups = $('.input-group').filter(function (i, inputGroup) {
-            return $(inputGroup).find('.form-control').length > 1;
-        });
-        if (badInputGroups.length) {
-            reporter('Input groups cannot contain multiple `.form-control`s', badInputGroups);
-        }
-    });
-    */
-    /*
     addLinter('E011', function lintFormGroupMixedWithInputGroup($, reporter) {
-        var badMixes = $('.input-group.form-group');
+        var badMixes = $('.input-group.form-group, .input-group.row, .input-group.form-row');
         if (badMixes.length) {
-            reporter('`.input-group` and `.form-group` cannot be used directly on the same element. Instead, nest the `.input-group` within the `.form-group`', badMixes);
+            reporter('`.input-group` and `.form-group`/`.row`/`.form-row` cannot be used directly on the same element. Instead, nest the `.input-group` within the `.form-group`/`.row`/`.form-row`', badMixes);
         }
     });
-    */
-    /*
     addLinter('E012', function lintGridClassMixedWithInputGroup($, reporter) {
         var selector = COL_CLASSES.map(function (colClass) {
             return '.input-group' + colClass;
@@ -767,10 +753,9 @@ var LocationIndex = _location.LocationIndex;
 
         var badMixes = $(selector);
         if (badMixes.length) {
-            reporter('`.input-group` and `.col-*-*` cannot be used directly on the same element. Instead, nest the `.input-group` within the `.col-*-*`', badMixes);
+            reporter('`.input-group` and `.col*` cannot be used directly on the same element. Instead, nest the `.input-group` within the `.col*`', badMixes);
         }
     });
-    */
     /*
     addLinter('E013', function lintRowChildrenAreCols($, reporter) {
         var ALLOWED_CHILDREN = COL_CLASSES.concat(['script', '.clearfix', '.bs-customizer-input']);
@@ -793,22 +778,6 @@ var LocationIndex = _location.LocationIndex;
         var colsOutsideRowsAndFormGroups = $(selector);
         if (colsOutsideRowsAndFormGroups.length) {
             reporter('Columns (`.col-*-*`) can only be children of `.row`s or `.form-group`s', colsOutsideRowsAndFormGroups);
-        }
-    });
-    */
-    /*
-    addLinter('E015', function lintInputGroupsWithMultipleAddOnsPerSide($, reporter) {
-        var addOnClasses = ['.input-group-addon', '.input-group-btn'];
-        var combos = [];
-        addOnClasses.forEach(function (first) {
-            addOnClasses.forEach(function (second) {
-                combos.push('.input-group>' + first + '+' + second);
-            });
-        });
-        var selector = combos.join(',');
-        var multipleAddOns = $(selector);
-        if (multipleAddOns.length) {
-            reporter('Having multiple add-ons on a single side of an input group is not supported', multipleAddOns);
         }
     });
     */
@@ -1168,17 +1137,15 @@ var LocationIndex = _location.LocationIndex;
         }
     });
     */
-    /*
     addLinter('E044', function lintInputGroupAddonChildren($, reporter) {
         var badInputGroups = $('.input-group').filter(function () {
             var inputGroup = $(this);
-            return !inputGroup.children('.form-control').length || !inputGroup.children('.input-group-addon, .input-group-btn').length;
+            return !inputGroup.children('.form-control').length || !inputGroup.children('.input-group-prepend, .input-group-append').length;
         });
         if (badInputGroups.length) {
-            reporter('`.input-group` must have a `.form-control` and either an `.input-group-addon` or an `.input-group-btn`.', badInputGroups);
+            reporter('`.input-group` must have a `.form-control` and either an `.input-group-prepend` or `.input-group-append`.', badInputGroups);
         }
     });
-    */
     /*
     addLinter('E045', function lintImgResponsiveOnNonImgs($, reporter) {
         var imgResponsiveNotOnImg = $('.img-responsive:not(img)');

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -271,7 +271,6 @@ exports.bootlint = {
         test.done();
     },
     */
-    /*
     'btn/input sizing used without input-group-* size': function (test) {
         test.expect(1);
         test.deepEqual(lintHtml(utf8Fixture('input-group/missing-input-group-sizing.html')),
@@ -279,46 +278,30 @@ exports.bootlint = {
             'should complain when an input/btn sizes are used within input-group.');
         test.done();
     },
-    */
-    /*
-    'input groups with multiple form controls': function (test) {
-        test.expect(1);
-        test.deepEqual(lintHtml(utf8Fixture('input-group/multiple-form-controls.html')),
-            ['Input groups cannot contain multiple `.form-control`s'],
-            'should complain when an input group contains multiple form controls.');
-        test.done();
-    },
-    */
-    /*
     'mixing input groups with form groups': function (test) {
         test.expect(1);
         test.deepEqual(lintHtml(utf8Fixture('input-group/mixed-with-form-group.html')),
-            ['`.input-group` and `.form-group` cannot be used directly on the same element. Instead, nest the `.input-group` within the `.form-group`'],
-            'should complain when .input-group and .form-group are used on the same element.');
+            ['`.input-group` and `.form-group`/`.row`/`.form-row` cannot be used directly on the same element. Instead, nest the `.input-group` within the `.form-group`/`.row`/`.form-row`'],
+            'should complain when .input-group and .form-group/.row/.form-row are used on the same element.');
         test.done();
     },
-    */
-    /*
     'mixing input groups with grid columns': function (test) {
         test.expect(1);
         test.deepEqual(lintHtml(utf8Fixture('input-group/mixed-with-grid-col.html')),
-            ['`.input-group` and `.col-*-*` cannot be used directly on the same element. Instead, nest the `.input-group` within the `.col-*-*`'],
+            ['`.input-group` and `.col*` cannot be used directly on the same element. Instead, nest the `.input-group` within the `.col*`'],
             'should complain when an input group has a grid column class on it.');
         test.done();
     },
-    */
-    /*
     'input groups missing controls and addons': function (test) {
         test.expect(2);
         test.deepEqual(lintHtml(utf8Fixture('input-group/missing-input-group-addon.html')),
-            ['`.input-group` must have a `.form-control` and either an `.input-group-addon` or an `.input-group-btn`.'],
+            ['`.input-group` must have a `.form-control` and either an `.input-group-prepend` or `.input-group-append`.'],
             'should complain when missing missing a `.form-control`');
         test.deepEqual(lintHtml(utf8Fixture('input-group/missing-form-control.html')),
-            ['`.input-group` must have a `.form-control` and either an `.input-group-addon` or an `.input-group-btn`.'],
-            'should complain when missing missing a `.input-group-addon`');
+            ['`.input-group` must have a `.form-control` and either an `.input-group-prepend` or `.input-group-append`.'],
+            'should complain when missing missing a `.input-group-prepend`');
         test.done();
     },
-    */
     /*
     'non-column children of rows': function (test) {
         test.expect(2);
@@ -328,27 +311,6 @@ exports.bootlint = {
         test.deepEqual(lintHtml(utf8Fixture('grid/script-child-of-row.html')),
             [],
             'should not complain about <script> child of row');
-        test.done();
-    },
-    */
-    /*
-    'multiple columns on the same side of an input group': function (test) {
-        test.expect(5);
-        test.deepEqual(lintHtml(utf8Fixture('input-group/multiple-add-on-left.html')),
-            ['Having multiple add-ons on a single side of an input group is not supported'],
-            'should complain when multiple normal add-ons are on the left side of an input group.');
-        test.deepEqual(lintHtml(utf8Fixture('input-group/multiple-add-on-right.html')),
-            ['Having multiple add-ons on a single side of an input group is not supported'],
-            'should complain when multiple normal add-ons are on the right side of an input group.');
-        test.deepEqual(lintHtml(utf8Fixture('input-group/multiple-btn-add-on-left.html')),
-            ['Having multiple add-ons on a single side of an input group is not supported'],
-            'should complain when multiple button add-ons are on the left side of an input group.');
-        test.deepEqual(lintHtml(utf8Fixture('input-group/multiple-btn-add-on-right.html')),
-            ['Having multiple add-ons on a single side of an input group is not supported'],
-            'should complain when multiple button add-ons are on the right side of an input group.');
-        test.deepEqual(lintHtml(utf8Fixture('input-group/multiple-mixed-add-on-left.html')),
-            ['Having multiple add-ons on a single side of an input group is not supported'],
-            'should complain when both a normal add-on and a button add-on are on the left side of an input group.');
         test.done();
     },
     */


### PR DESCRIPTION
### Thinking aloud

- E006 (`.input-group` contains a `<select>`/`<textarea>`) ➜ Works now with `<select>`/`<textarea>` with the `.form-control`/`.custom-select` classes respectively (<https://getbootstrap.com/docs/4.1/components/input-group/#custom-select>/<https://getbootstrap.com/docs/4.1/components/input-group/#basic-example>) ➜ Replace with new checks in future but remove for now
- E009 (Button and input sizing within `.input-group`s can cause issues.) ➜ Still applies? ➜ Change `.input-lg` into `.form-control-lg`
- E010 (Input groups cannot contain multiple `.form-control`s) ➜ Works at least with multiple `<input>`s except for validation (<https://getbootstrap.com/docs/4.1/components/input-group/#multiple-inputs>) ➜ Warning? Remove for now.
- E011 (.input-group` and `.form-group` cannot be used directly on the same element) ➜ Still applies I guess ➜ Port by adding `row`/`.form-row`
- E012 (.input-group` and `.col-*-*` cannot be used directly on the same element) ➜ Port
- E015 (Multiple add-ons on a single side of an input group not allowed) ➜ Works now (<https://getbootstrap.com/docs/4.1/components/input-group/#multiple-addons>) ➜ Remove check
- E044

### Changes

E006, E010, E015 removed and E009, E011, E012 ported

### Status

- Code: Assumed to done (TODO: check why test fails though)
- Tests: Assumed to done (TODO: check why test fails though)
- Wiki: Not yet