### PR TITLE
[v1] Panels are cards now

### DIFF
--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -878,38 +878,38 @@ var LocationIndex = _location.LocationIndex;
         }
     });
     */
-    /*
-    addLinter('E023', function lintPanelBodyWithoutPanel($, reporter) {
-        var badPanelBody = $('.panel-body').parent(':not(.panel, .panel-collapse)');
-        if (badPanelBody.length) {
-            reporter('`.panel-body` must have a `.panel` or `.panel-collapse` parent', badPanelBody);
+    addLinter('E023', function lintCardBodyWithoutCard($, reporter) {
+        var badCardBody = $('.card-body').filter(function () {
+            return $(this).closest('.card').length !== 1;
+        });
+        if (badCardBody.length) {
+            reporter('`.card-body` must have `.card` or have it as an ancestor.', badCardBody);
         }
     });
-    */
-    /*
-    addLinter('E024', function lintPanelHeadingWithoutPanel($, reporter) {
-        var badPanelHeading = $('.panel-heading').parent(':not(.panel)');
-        if (badPanelHeading.length) {
-            reporter('`.panel-heading` must have a `.panel` parent', badPanelHeading);
+    addLinter('E024', function lintCardHeaderWithoutCard($, reporter) {
+        var badCardHeader = $('.card-header').filter(function () {
+            return $(this).parents('.card').length !== 1;
+        });
+        if (badCardHeader.length) {
+            reporter('`.card-header` must have a `.card` ancestor.', badCardHeader);
         }
     });
-    */
-    /*
-    addLinter('E025', function lintPanelFooterWithoutPanel($, reporter) {
-        var badPanelFooter = $('.panel-footer').parent(':not(.panel, .panel-collapse)');
-        if (badPanelFooter.length) {
-            reporter('`.panel-footer` must have a `.panel` or `.panel-collapse` parent', badPanelFooter);
+    addLinter('E025', function lintCardFooterWithoutCard($, reporter) {
+        var badCardFooter = $('.card-footer').filter(function () {
+            return $(this).parents('.card').length !== 1;
+        });
+        if (badCardFooter.length) {
+            reporter('`.card-footer` must have a `.card` ancestor.', badCardFooter);
         }
     });
-    */
-    /*
-    addLinter('E026', function lintPanelTitleWithoutPanelHeading($, reporter) {
-        var badPanelTitle = $('.panel-title').parent(':not(.panel-heading)');
-        if (badPanelTitle.length) {
-            reporter('`.panel-title` must have a `.panel-heading` parent', badPanelTitle);
+    addLinter('E026', function lintCardTitleWithoutCard($, reporter) {
+        var badCardTitle = $('.card-title').filter(function () {
+            return $(this).parents('.card').length !== 1;
+        });
+        if (badCardTitle.length) {
+            reporter('`.card-title` must have a `.card` ancestor.', badCardTitle);
         }
     });
-    */
     /*
     addLinter('E027', function lintTableResponsive($, reporter) {
         var badStructure = $('.table.table-responsive, table.table-responsive');

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -460,27 +460,25 @@ exports.bootlint = {
         test.done();
     },
     */
-    /*
-    'panel structure': function (test) {
+    'card structure': function (test) {
         test.expect(5);
-        test.deepEqual(lintHtml(utf8Fixture('panels/panels.html')),
+        test.deepEqual(lintHtml(utf8Fixture('cards/cards.html')),
             [],
-            'should not complain when panel is structured correctly.');
-        test.deepEqual(lintHtml(utf8Fixture('panels/panel-body-missing-parent.html')),
-            ['`.panel-body` must have a `.panel` or `.panel-collapse` parent'],
-            'should complain when .panel-body is missing .panel or .panel-collapse parent');
-        test.deepEqual(lintHtml(utf8Fixture('panels/panel-footer-missing-parent.html')),
-            ['`.panel-footer` must have a `.panel` or `.panel-collapse` parent'],
-            'should complain when .panel-footer is missing .panel parent');
-        test.deepEqual(lintHtml(utf8Fixture('panels/panel-title-missing-parent.html')),
-            ['`.panel-title` must have a `.panel-heading` parent'],
-            'should complain when .panel-title is missing .panel-heading parent');
-        test.deepEqual(lintHtml(utf8Fixture('panels/panel-heading-missing-parent.html')),
-            ['`.panel-heading` must have a `.panel` parent'],
-            'should complain when .panel-heading is missing .panel parent');
+            'should not complain when card is structured correctly.');
+        test.deepEqual(lintHtml(utf8Fixture('cards/card-body-missing-ancestor.html')),
+            ['`.card-body` must have `.card` or have it as an ancestor.'],
+            'should complain when .card-body is missing .card ancestor');
+        test.deepEqual(lintHtml(utf8Fixture('cards/card-footer-missing-ancestor.html')),
+            ['`.card-footer` must have a `.card` ancestor.'],
+            'should complain when .card-footer is missing .card ancestor');
+        test.deepEqual(lintHtml(utf8Fixture('cards/card-title-missing-ancestor.html')),
+            ['`.card-title` must have a `.card` ancestor.'],
+            'should complain when .card-title is missing .card ancestor');
+        test.deepEqual(lintHtml(utf8Fixture('cards/card-header-missing-ancestor.html')),
+            ['`.card-header` must have a `.card` ancestor.'],
+            'should complain when .card-header is missing .card ancestor');
         test.done();
     },
-    */
     'columns outside of rows and form groups': function (test) {
         test.expect(3);
         test.deepEqual(lintHtml(utf8Fixture('grid/cols-within-row.html')),

--- a/test/fixtures/cards/card-body-missing-ancestor.html
+++ b/test/fixtures/cards/card-body-missing-ancestor.html
@@ -18,13 +18,15 @@
     </head>
     <body>
 
-      <div class="panel">
-          <h2 class="panel-title">Panel title</h2>
+      <div>
+          <div class="card-body">
+            <p>Something</p>
+          </div>
       </div>
 
         <div id="qunit"></div>
         <ol id="bootlint">
-          <li data-lint="`.panel-title` must have a `.panel-heading` parent"></li>
+          <li data-lint="`.card-body` must have `.card` or have it as an ancestor."> </li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/cards/card-footer-missing-ancestor.html
+++ b/test/fixtures/cards/card-footer-missing-ancestor.html
@@ -19,14 +19,14 @@
     <body>
 
       <div>
-          <div class="panel-body">
+          <div class="card-footer">
             <p>Something</p>
           </div>
       </div>
 
         <div id="qunit"></div>
         <ol id="bootlint">
-          <li data-lint="`.panel-body` must have a `.panel` or `.panel-collapse` parent"> </li>
+          <li data-lint="`.card-footer` must have a `.card` ancestor."></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/cards/card-header-missing-ancestor.html
+++ b/test/fixtures/cards/card-header-missing-ancestor.html
@@ -19,14 +19,14 @@
     <body>
 
       <div>
-          <div class="panel-footer">
+          <div class="card-header">
             <p>Something</p>
           </div>
       </div>
 
         <div id="qunit"></div>
         <ol id="bootlint">
-          <li data-lint="`.panel-footer` must have a `.panel` or `.panel-collapse` parent"></li>
+          <li data-lint="`.card-header` must have a `.card` ancestor."></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/cards/card-title-missing-ancestor.html
+++ b/test/fixtures/cards/card-title-missing-ancestor.html
@@ -19,14 +19,12 @@
     <body>
 
       <div>
-          <div class="panel-heading">
-            <p>Something</p>
-          </div>
+          <h2 class="card-title">Card title</h2>
       </div>
 
         <div id="qunit"></div>
         <ol id="bootlint">
-          <li data-lint="`.panel-heading` must have a `.panel` parent"></li>
+          <li data-lint="`.card-title` must have a `.card` ancestor."></li>
         </ol>
     </body>
 </html>

--- a/test/fixtures/cards/cards.html
+++ b/test/fixtures/cards/cards.html
@@ -18,73 +18,74 @@
     </head>
     <body>
 
-        <!-- Basic Panel -->
-        <div class="panel">
-          <div class="panel-heading">
-            <h1 class="panel-title">Title</h1>
+
+        <!-- Basic Card -->
+        <div class="card">
+          <div class="card-header">
+            <h1 class="card-title">Title</h1>
           </div>
-          <div class="panel-body">
+          <div class="card-body">
             <p>Something</p>
           </div>
-          <div class="panel-footer">
+          <div class="card-footer">
             <p>Footer</p>
           </div>
         </div>
 
-        <!-- Panel accordion example -->
-        <div class="panel-group" id="accordion">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h4 class="panel-title">
+        <!-- Card accordion example -->
+        <div class="accordion" id="accordion">
+          <div class="card">
+            <div class="card-header">
+              <h4 class="card-title">
                 <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne">
                   Collapsible Group Item #1
                 </a>
               </h4>
             </div>
-            <div id="collapseOne" class="panel-collapse collapse in">
-              <div class="panel-body">
+            <div id="collapseOne" class="collapse in">
+              <div class="card-body">
                 Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.
               </div>
             </div>
           </div>
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h4 class="panel-title">
+          <div class="card">
+            <div class="card-header">
+              <h4 class="card-title">
                 <a data-toggle="collapse" data-parent="#accordion" href="#collapseTwo">
                   Collapsible Group Item #2
                 </a>
               </h4>
             </div>
-            <div id="collapseTwo" class="panel-collapse collapse">
-              <div class="panel-body">
+            <div id="collapseTwo" class="collapse">
+              <div class="card-body">
                 Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.
               </div>
             </div>
           </div>
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h4 class="panel-title">
+          <div class="card">
+            <div class="card-header">
+              <h4 class="card-title">
                 <a data-toggle="collapse" data-parent="#accordion" href="#collapseThree">
                   Collapsible Group Item #3
                 </a>
               </h4>
             </div>
-            <div id="collapseThree" class="panel-collapse collapse">
-              <div class="panel-body">
+            <div id="collapseThree" class="collapse">
+              <div class="card-body">
                 Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus labore sustainable VHS.
               </div>
             </div>
           </div>
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h4 class="panel-title">
+          <div class="card">
+            <div class="card-header">
+              <h4 class="card-title">
                 <a data-toggle="collapse" data-parent="#accordion" href="#collapseFour">
                   Collapsible Group Item #3
                 </a>
               </h4>
             </div>
-            <div id="collapseFour" class="panel-collapse collapse">
-              <div class="panel-footer">Footer</div>
+            <div id="collapseFour" class="collapse">
+              <div class="card-footer">Footer</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Port E023, E024, E025, and E026

Basically the changes mentioned at https://getbootstrap.com/docs/4.1/migration/#panels but also the fact that `.card` does not need to be a direct parent anymore and also can be directly combined with `.card-body` on the same element (I can't remember what made me think that latter applies though, it has been a year).

What could be added in the future are tests for `.card-group`/`.card-deck`/`.card-columns` and making sure that `.card-title`/`.card-subtitle` are added to a `<h*>` and `.card-link` to `<a>` elements (#424).

- **Code**: Done but I am unsure about whether having both `.card-body` and `.card` is really a good idea and I still don't remember where I got the idea that it might be.
- **Tests**: Done.
- **Wiki**: Done.