### PR TITLE
Tweak Travis scripts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ node_js:
 install:
     - npm install
 before_script:
-    - git clone --depth 1 https://github.com/twbs/bootstrap.git --branch v3-dev
-    - bundle install --deployment --gemfile bootstrap/Gemfile --jobs=3 --retry=3
+    - git clone --depth 1 https://github.com/twbs/bootstrap.git --branch v3-dev || travis_terminate 1
+    - bundle install --deployment --gemfile bootstrap/Gemfile --jobs=3 --retry=3 || travis_terminate 1
     - pushd bootstrap && bundle exec jekyll build && popd
 script:
-    - npm run travis
-    - node ./src/cli-main.js --disable W003,W005 "bootstrap/_gh_pages/**/index.html"
-    - node ./src/cli-main.js --disable W003,E001 test/fixtures/doctype/missing.html test/fixtures/viewport/missing.html
+    - npm run travis || travis_terminate 1
+    - if [ "$TRAVIS_NODE_VERSION" = "10" ]; then npm run qunit; fi || travis_terminate 1
+    - node ./src/cli-main.js --disable W003,W005 "bootstrap/_gh_pages/**/index.html" || travis_terminate 1
     - node ./src/cli-main.js test/fixtures/x-ua-compatible/missing.html &> x-ua-compatible-missing.output.actual.txt || true
     - diff test/fixtures/cli/x-ua-compatible-missing.output.txt x-ua-compatible-missing.output.actual.txt
 after_success:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nodeunit": "nodeunit test",
     "qunit": "node build/phantom.js",
     "start": "node ./bin/www",
-    "test": "npm run eslint && npm run build && npm run nodeunit && npm run qunit",
+    "test": "npm run eslint && npm run build && npm run nodeunit",
     "travis": "nyc npm test"
   },
   "dependencies": {


### PR DESCRIPTION
* add `travis_terminate 1` so that subsequent tests are skipped
* run `qunit` tests only on Node 10.

/CC @bardiharborow @Johann-S: it seems it works quite well. I haven't tested when things fail, though, if we are still covering all the cases we covered before. Now the build will exit as soon we hit an error.

All in all this really speeds up Travis builds, we save ~75% from the total time.