### PR TITLE
More tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
     - bundle install --deployment --gemfile bootstrap/Gemfile --jobs=3 --retry=3 || travis_terminate 1
     - pushd bootstrap && bundle exec jekyll build && popd
 script:
-    - if [ "$TRAVIS_NODE_VERSION" = "10" ]; then npm run nyc -- npm run test:all; else npm run nyc -- npm run test; fi || travis_terminate 1
+    - if [ "$TRAVIS_NODE_VERSION" = "10" ]; then npm run nyc -- npm run test:all; else npm run test; fi || travis_terminate 1
     - node ./src/cli-main.js --disable W003,W005 "bootstrap/_gh_pages/**/index.html" || travis_terminate 1
     - node ./src/cli-main.js test/fixtures/x-ua-compatible/missing.html &> x-ua-compatible-missing.output.actual.txt || true
     - diff test/fixtures/cli/x-ua-compatible-missing.output.txt x-ua-compatible-missing.output.actual.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
     - bundle install --deployment --gemfile bootstrap/Gemfile --jobs=3 --retry=3 || travis_terminate 1
     - pushd bootstrap && bundle exec jekyll build && popd
 script:
-    - if [ "$TRAVIS_NODE_VERSION" = "10" ]; then npm run nyc -- npm run test:all; else npm run test; fi || travis_terminate 1
+    - if [ "$TRAVIS_NODE_VERSION" = "10" ]; then npm run nyc -- npm run test && npm run qunit; else npm run test; fi || travis_terminate 1
     - node ./src/cli-main.js --disable W003,W005 "bootstrap/_gh_pages/**/index.html" || travis_terminate 1
     - node ./src/cli-main.js test/fixtures/x-ua-compatible/missing.html &> x-ua-compatible-missing.output.actual.txt || true
     - diff test/fixtures/cli/x-ua-compatible-missing.output.txt x-ua-compatible-missing.output.actual.txt

--- a/src/bootlint.js
+++ b/src/bootlint.js
@@ -74,7 +74,7 @@ var LocationIndex = _location.LocationIndex;
             return element.name.toUpperCase();
         } :
         function (element) {
-            /* @covignore */
+            /* istanbul ignore next */
             return element.tagName.toUpperCase();
         };
 
@@ -226,7 +226,7 @@ var LocationIndex = _location.LocationIndex;
     }
 
     function jqueryPluginVersions(jQuery) {
-        /* @covignore */
+        /* istanbul ignore next */
         return PLUGINS.map(function (pluginName) {
             var plugin = jQuery.fn[pluginName];
             if (!plugin) {
@@ -291,7 +291,7 @@ var LocationIndex = _location.LocationIndex;
     var allLinters = {};
     function addLinter(id, linter) {
         if (allLinters[id]) {
-            /* @covignore */
+            /* istanbul ignore next */
             throw new Error('Linter already registered with ID: ' + id);
         }
 
@@ -301,7 +301,7 @@ var LocationIndex = _location.LocationIndex;
         } else if (id[0] === 'W') {
             Problem = LintWarning;
         } else {
-            /* @covignore */
+            /* istanbul ignore next */
             throw new Error('Invalid linter ID: ' + id);
         }
 
@@ -371,7 +371,7 @@ var LocationIndex = _location.LocationIndex;
             // deliberately do nothing
             // empty
         }
-        /* @covignore */
+        /* istanbul ignore if */
         if (theWindow) {
             // check browser global jQuery
             var globaljQuery = theWindow.$ || theWindow.jQuery;
@@ -512,7 +512,7 @@ var LocationIndex = _location.LocationIndex;
         var OUTDATED_BOOTSTRAP = 'Bootstrap version might be outdated. Latest version is at least ' + CURRENT_BOOTSTRAP_VERSION + ' ; saw what appears to be usage of Bootstrap ';
         var theWindow = getBrowserWindowObject();
         var globaljQuery = theWindow && (theWindow.$ || theWindow.jQuery);
-        /* @covignore */
+        /* istanbul ignore if */
         if (globaljQuery) {
             var versions = jqueryPluginVersions(globaljQuery);
             if (versions.length) {
@@ -552,7 +552,7 @@ var LocationIndex = _location.LocationIndex;
         var theWindow = getBrowserWindowObject();
 
         var globaljQuery = theWindow && (theWindow.$ || theWindow.jQuery);
-        /* @covignore */
+        /* istanbul ignore if */
         if (globaljQuery) {
             var versions = jqueryPluginVersions(globaljQuery);
             if (versions.length) {
@@ -608,7 +608,7 @@ var LocationIndex = _location.LocationIndex;
             };
         }
 
-        /* @covignore */
+        /* istanbul ignore next */
         return function lintDoctype($, reporter) {
             /* eslint-disable no-undef, block-scoped-var */
             var doc = window.document;
@@ -1184,7 +1184,7 @@ var LocationIndex = _location.LocationIndex;
         };
     } else {
         // jQuery; in-browser
-        /* @covignore */
+        /* istanbul ignore next */
         (function () {
             var $ = cheerio;
             /**

--- a/src/location.js
+++ b/src/location.js
@@ -40,7 +40,7 @@ var binarySearch = require('binary-search');
         while (charIndex < string.length) {
             charIndex = string.indexOf('\n', charIndex);
             if (charIndex === -1) {
-                /* @covignore */
+                /* istanbul ignore next */
                 break;
             }
             charIndex++;// go past the newline
@@ -72,8 +72,10 @@ var binarySearch = require('binary-search');
             return 0;
 
         });
-        if (index < 0) { // binarySearch returns a negative number (but not necessarily -1) when match not found
-            /* @covignore */
+
+        // binarySearch returns a negative number (but not necessarily -1) when match not found
+        if (index < 0) {
+            /* istanbul ignore next */
             return null;
         }
         var lineStartEnd = this._lineStartEndTriples[index];


### PR DESCRIPTION
* Replace old coverage ignore directives with the istanbul ones.
* Travis: we don't need nyc in Node.js < 10; we only run coveralls in Node.js 10.
* Travis: run qunit tests without nyc; this slows down qunit tests a lot, ~10 times.