### PR TITLE
Travis CI: Add Node.js 12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
     - "6"
     - "8"
     - "10"
+    - "12"
 install:
     - npm install
 before_script:


### PR DESCRIPTION
Apparently this is broken due to source-map-support.

```
C:\Users\xmr\Desktop\bootlint>npm ls source-map-support
bootlint@0.16.6 C:\Users\xmr\Desktop\bootlint
+-- nodeunit@0.11.3
| `-- tap@12.7.0
|   +-- source-map-support@0.5.12  deduped
|   `-- ts-node@8.3.0
|     `-- source-map-support@0.5.12  deduped
`-- terser@4.1.2
  `-- source-map-support@0.5.12
```

Which means that bootlint itself should work fine on Node.js 12 since these are devDependencies. But it'd be nice if we could sort this out and actually test on Node.js 12 ourselves.